### PR TITLE
Fixed logging of extra gas switch when bailing out from CCR.

### DIFF
--- a/Discovery/Src/data_central.c
+++ b/Discovery/Src/data_central.c
@@ -543,7 +543,7 @@ void setActualGas_ExtraGas(SLifeData *lifeData, uint8_t oxygen, uint8_t helium, 
 	nitrogen -= oxygen;
 	nitrogen -= helium;
 
-
+    // This fix has been done upstream, and been cherry-picked in dd4d9ad43f910f8757440953675ce08a3e314c6e, closing this.
 	if((lifeData->actualGas.nitrogen_percentage != nitrogen) || (lifeData->actualGas.helium_percentage != helium) || (lifeData->actualGas.AppliedDiveMode != DIVEMODE_OC))
     {
     	stateUsedWrite->events.manualGasSet = 1;


### PR DESCRIPTION
Create a log entry for a manual gas switch to an identical OC gas if the switch happens from a closed circuit mode.