### PR TITLE
Add Current Compass Heading Display.

### DIFF
--- a/Common/Inc/data_central.h
+++ b/Common/Inc/data_central.h
@@ -293,7 +293,9 @@ typedef struct
 	int16_t bailout;
 	int16_t info_bailoutHe;
 	int16_t info_bailoutO2;
-} 	SEvents;
+    int16_t compassHeadingUpdate;
+    uint16_t info_compassHeadingUpdate;
+} SEvents;
 
 
 
@@ -520,6 +522,8 @@ _Bool is_ambient_pressure_close_to_surface(SLifeData *lifeData);
 uint8_t isLoopMode(uint8_t Mode);
 
 bool isCompassCalibrated(void);
+void logCompassHeading(uint16_t heading);
+void clearCompassHeading(void);
 void setCompassHeading(uint16_t heading);
 
 const SDecoinfo *getDecoInfo(void);

--- a/Discovery/Inc/tStructure.h
+++ b/Discovery/Inc/tStructure.h
@@ -203,6 +203,7 @@
 #define StMXTRA_CompassHeading	_MB(2,4,2,1,0)
 #define StMXTRA_CompassHeadingClear	_MB(2,4,2,2,0)
 #define StMXTRA_CompassHeadingReset	_MB(2,4,2,3,0)
+#define StMXTRA_CompassHeadingLog	_MB(2,4,2,4,0)
 
  /* SURFACE MODE */
 

--- a/Discovery/Inc/text_multilanguage.h
+++ b/Discovery/Inc/text_multilanguage.h
@@ -377,6 +377,7 @@ extern const tText text_array2[];
         TXT2BYTE_Page,
 
         TXT2BYTE_Current,
+        TXT2BYTE_Log,
 
 		TXT2BYTE_END,
 };

--- a/Discovery/Inc/text_multilanguage.h
+++ b/Discovery/Inc/text_multilanguage.h
@@ -376,6 +376,8 @@ extern const tText text_array2[];
 
         TXT2BYTE_Page,
 
+        TXT2BYTE_Current,
+
 		TXT2BYTE_END,
 };
 

--- a/Discovery/Src/data_central.c
+++ b/Discovery/Src/data_central.c
@@ -875,13 +875,38 @@ bool isCompassCalibrated(void)
     return stateUsed->lifeData.compass_heading != -1;
 }
 
+static void internalLogCompassHeading(uint16_t heading, bool applyHeading, bool clearHeading)
+{
+    uint16_t compassHeading = 0;
+    if (clearHeading) {
+        compassHeading |= 0x8000;
+    } else {
+        compassHeading = heading & 0x1FF;
+    }
+    if (applyHeading) {
+        compassHeading |= 0x4000;
+    }
+
+    stateUsedWrite->events.compassHeadingUpdate = 1;
+    stateUsedWrite->events.info_compassHeadingUpdate = compassHeading;
+}
+
+void logCompassHeading(uint16_t heading) {
+    internalLogCompassHeading(heading, false, false);
+}
+
+void clearCompassHeading(void) {
+    uint16_t clearHeading = 0;
+    stateUsedWrite->diveSettings.compassHeading = clearHeading;
+
+    internalLogCompassHeading(clearHeading, true, true);
+}
 
 void setCompassHeading(uint16_t heading)
 {
-
-    // if heading == 0 set compassHeading to 360, because compassHeading == 0 means 'off'
-
     stateUsedWrite->diveSettings.compassHeading =  ((heading - 360) % 360) + 360;
+
+    internalLogCompassHeading(heading, true, false);
 }
 
 

--- a/Discovery/Src/logbook.c
+++ b/Discovery/Src/logbook.c
@@ -458,6 +458,10 @@ void logbook_writeSample(const SDiveState *state)
         eventByte1.ub.bit7 = 1;
         eventByte2.ub.bit0 = 1;
     }
+    if (state->events.compassHeadingUpdate) {
+        eventByte1.ub.bit7 = 1;
+        eventByte2.ub.bit1 = 1;
+    }
     //Add EventByte 1
     if(eventByte1.uw > 0)
     {
@@ -497,6 +501,11 @@ void logbook_writeSample(const SDiveState *state)
         length += 1;
         sample[length] = state->events.info_bailoutHe;
         length += 1;
+    }
+    if (state->events.compassHeadingUpdate) {
+        // New heading and type of heading
+        sample[length++] = state->events.info_compassHeadingUpdate & 0xFF;
+        sample[length++] = (state->events.info_compassHeadingUpdate & 0xFF00) >> 8;
     }
 
 

--- a/Discovery/Src/tMenuEditXtra.c
+++ b/Discovery/Src/tMenuEditXtra.c
@@ -427,6 +427,11 @@ static void drawCompassHeadingMenu(bool isRefresh)
         write_label_var(20, 800, ME_Y_LINE4, &FontT48, text);
     }
 
+    if (headingIsSet) {
+        snprintf(text, 32, "%s%c%c (%03u`)", makeGrey(true), TXT_2BYTE, TXT2BYTE_Current, stateUsed->diveSettings.compassHeading);
+        write_label_var(20, 800, ME_Y_LINE5, &FontT48, text);
+    }
+
     if (!isRefresh) {
         setEvent(StMXTRA_CompassHeading, (uint32_t)OnAction_CompassHeading);
         setEvent(StMXTRA_CompassHeadingClear, (uint32_t)OnAction_CompassHeadingClear);

--- a/Discovery/Src/tMenuEditXtra.c
+++ b/Discovery/Src/tMenuEditXtra.c
@@ -360,7 +360,7 @@ static void openEdit_CO2Sensor()
 
 static uint8_t OnAction_CompassHeadingClear(uint32_t editId, uint8_t blockNumber, uint8_t digitNumber, uint8_t digitContent, uint8_t action)
 {
-    stateUsedWrite->diveSettings.compassHeading = 0;
+    clearCompassHeading();
 
     exitMenuEdit_to_Home_with_Menu_Update();
 
@@ -370,7 +370,17 @@ static uint8_t OnAction_CompassHeadingClear(uint32_t editId, uint8_t blockNumber
 
 static uint8_t OnAction_CompassHeadingReset(uint32_t editId, uint8_t blockNumber, uint8_t digitNumber, uint8_t digitContent, uint8_t action)
 {
-    stateUsedWrite->diveSettings.compassHeading = settingsGetPointer()->compassBearing;
+    setCompassHeading(settingsGetPointer()->compassBearing);
+
+    exitMenuEdit_to_Home_with_Menu_Update();
+
+    return EXIT_TO_HOME;
+}
+
+
+static uint8_t OnAction_CompassHeadingLog(uint32_t editId, uint8_t blockNumber, uint8_t digitNumber, uint8_t digitContent, uint8_t action)
+{
+	logCompassHeading((uint16_t)stateUsed->lifeData.compass_heading);
 
     exitMenuEdit_to_Home_with_Menu_Update();
 
@@ -427,15 +437,23 @@ static void drawCompassHeadingMenu(bool isRefresh)
         write_label_var(20, 800, ME_Y_LINE4, &FontT48, text);
     }
 
+    snprintf(text, 32, "%c%c", TXT_2BYTE, TXT2BYTE_Log);
+    if (!isRefresh) {
+        write_field_button(StMXTRA_CompassHeadingLog, 20, 800, ME_Y_LINE5, &FontT48, text);
+    } else {
+        tMenuEdit_refresh_field(StMXTRA_CompassHeadingLog);
+    }
+
     if (headingIsSet) {
         snprintf(text, 32, "%s%c%c (%03u`)", makeGrey(true), TXT_2BYTE, TXT2BYTE_Current, stateUsed->diveSettings.compassHeading);
-        write_label_var(20, 800, ME_Y_LINE5, &FontT48, text);
+        write_label_var(20, 800, ME_Y_LINE6, &FontT48, text);
     }
 
     if (!isRefresh) {
         setEvent(StMXTRA_CompassHeading, (uint32_t)OnAction_CompassHeading);
         setEvent(StMXTRA_CompassHeadingClear, (uint32_t)OnAction_CompassHeadingClear);
         setEvent(StMXTRA_CompassHeadingReset, (uint32_t)OnAction_CompassHeadingReset);
+        setEvent(StMXTRA_CompassHeadingLog, (uint32_t)OnAction_CompassHeadingLog);
     }
 
     write_buttonTextline(TXT2BYTE_ButtonBack, TXT2BYTE_ButtonEnter, TXT2BYTE_ButtonNext);

--- a/Discovery/Src/text_multilanguage.c
+++ b/Discovery/Src/text_multilanguage.c
@@ -1531,6 +1531,7 @@ static uint8_t text_DE_FocusSpotSize[] = "Fokus Reaktion:";
 static uint8_t text_FR_FocusSpotSize[] = "";
 static uint8_t text_IT_FocusSpotSize[] = "";
 static uint8_t text_ES_FocusSpotSize[] = "";
+
 /*
 static uint8_t text_EN_ApneaCount[] = "";
 static uint8_t text_DE_ApneaCount[] = "";
@@ -1907,6 +1908,12 @@ static uint8_t text_FR_Page[] = "Défiler";
 static uint8_t text_IT_Page[] = "Scorrere";
 static uint8_t text_ES_Page[] = "Desplazarse";
 
+static uint8_t text_EN_Current[] = "Current";
+static uint8_t text_DE_Current[] = "Aktuell";
+static uint8_t text_FR_Current[] = "Actuel";
+static uint8_t text_IT_Current[] = "Attuale";
+static uint8_t text_ES_Current[] = "Actual";
+
 /* Lookup Table -------------------------------------------------------------*/
 
 const tText text_array[] =
@@ -2020,7 +2027,7 @@ const tText text_array2[] =
 	{(uint8_t)TXT2BYTE_SetMarkerShort,	{text_EN_SetMarkerShort, text_DE_SetMarkerShort, text_FR_SetMarkerShort, text_IT_SetMarkerShort, text_ES_SetMarkerShort}},
 	{(uint8_t)TXT2BYTE_CheckMarker,		{text_EN_CheckMarker, text_DE_CheckMarker, text_FR_CheckMarker, text_IT_CheckMarker, text_ES_CheckMarker}},
     {(uint8_t)TXT2BYTE_CompassHeading,  {text_EN_CompassHeading, text_DE_CompassHeading, text_FR_CompassHeading, text_IT_CompassHeading, text_ES_CompassHeading}},
-	{(uint8_t)TXT2BYTE_CalibView,  		{text_EN_CalibView, text_DE_CalibView, text_FR_CalibView, text_IT_CalibView, text_ES_CalibView}},
+	{(uint8_t)TXT2BYTE_CalibView,		{text_EN_CalibView, text_DE_CalibView, text_FR_CalibView, text_IT_CalibView, text_ES_CalibView}},
 	{(uint8_t)TXT2BYTE_IndicateFrame,	{text_EN_IndicateFrame, text_DE_IndicateFrame, text_FR_IndicateFrame, text_IT_IndicateFrame, text_ES_IndicateFrame}},
 	{(uint8_t)TXT2BYTE_BoostBacklight,	{text_EN_BoostBacklight, text_DE_BoostBacklight, text_FR_BoostBacklight, text_IT_BoostBacklight, text_ES_BoostBacklight}},
 	{(uint8_t)TXT2BYTE_FocusSpotSize,	{text_EN_FocusSpotSize, text_DE_FocusSpotSize, text_FR_FocusSpotSize, text_IT_FocusSpotSize, text_ES_FocusSpotSize}},
@@ -2197,4 +2204,6 @@ const tText text_array2[] =
 	{(uint8_t)TXT2BYTE_Finished, 	{text_EN_Finished, text_DE_Finished, text_FR_Finished, text_IT_Finished, text_ES_Finished}},
 
 	{(uint8_t)TXT2BYTE_Page, 	{text_EN_Page, text_DE_Page, text_FR_Page, text_IT_Page, text_ES_Page}},
+
+	{(uint8_t)TXT2BYTE_Current, 	{text_EN_Current, text_DE_Current, text_FR_Current, text_IT_Current, text_ES_Current}},
 };

--- a/Discovery/Src/text_multilanguage.c
+++ b/Discovery/Src/text_multilanguage.c
@@ -1914,6 +1914,12 @@ static uint8_t text_FR_Current[] = "Actuel";
 static uint8_t text_IT_Current[] = "Attuale";
 static uint8_t text_ES_Current[] = "Actual";
 
+static uint8_t text_EN_Log[] = "Log";
+static uint8_t text_DE_Log[] = "Aufzeichnen";
+static uint8_t text_FR_Log[] = "Enregistrer";
+static uint8_t text_IT_Log[] = "Registrare";
+static uint8_t text_ES_Log[] = "Registrar";
+
 /* Lookup Table -------------------------------------------------------------*/
 
 const tText text_array[] =
@@ -2206,4 +2212,5 @@ const tText text_array2[] =
 	{(uint8_t)TXT2BYTE_Page, 	{text_EN_Page, text_DE_Page, text_FR_Page, text_IT_Page, text_ES_Page}},
 
 	{(uint8_t)TXT2BYTE_Current, 	{text_EN_Current, text_DE_Current, text_FR_Current, text_IT_Current, text_ES_Current}},
+	{(uint8_t)TXT2BYTE_Log, 	{text_EN_Log, text_DE_Log, text_FR_Log, text_IT_Log, text_ES_Log}},
 };


### PR DESCRIPTION
Add a line to the compass heading dive menu that shows the currently set heading to enable the diver to confirm it / add it to notes.

![IMG_20241201_134632](https://github.com/user-attachments/assets/e8d03cb7-cc86-4f81-9741-3f316dae0f9e)

Also add a log entry every time a new compass heading is set or the heading is cleared.


And add a way to add compass headings to the log without changing the currently set heading - this was added after discussion with cave divers who are interested in recording headings when mapping out caves.

Example implementation in Subsurface:
```
  <event time='0:10 min' type='23' flags='8' value='73' name='heading' />
  <event time='0:22 min' type='23' flags='8' value='327' name='heading' />
  <event time='0:36 min' type='23' flags='8' value='75' name='heading' />
  <event time='0:42 min' type='26' flags='8' name='Cleared compass heading' />
  <event time='0:50 min' type='26' flags='8' value='76' name='Logged compass heading' />
```