### PR TITLE
Add 'Reverse' Action for Compass Heading

### DIFF
--- a/Discovery/Inc/tStructure.h
+++ b/Discovery/Inc/tStructure.h
@@ -201,9 +201,10 @@
 /* DIVE MODE */
 #define StMXTRA_ResetStopwatch	_MB(2,4,1,1,0)
 #define StMXTRA_CompassHeading	_MB(2,4,2,1,0)
-#define StMXTRA_CompassHeadingClear	_MB(2,4,2,2,0)
-#define StMXTRA_CompassHeadingReset	_MB(2,4,2,3,0)
-#define StMXTRA_CompassHeadingLog	_MB(2,4,2,4,0)
+#define StMXTRA_CompassHeadingReverse	_MB(2,4,2,2,0)
+#define StMXTRA_CompassHeadingClear	_MB(2,4,2,3,0)
+#define StMXTRA_CompassHeadingReset	_MB(2,4,2,4,0)
+#define StMXTRA_CompassHeadingLog	_MB(2,4,2,5,0)
 
  /* SURFACE MODE */
 

--- a/Discovery/Inc/text_multilanguage.h
+++ b/Discovery/Inc/text_multilanguage.h
@@ -378,6 +378,7 @@ extern const tText text_array2[];
 
         TXT2BYTE_Current,
         TXT2BYTE_Log,
+        TXT2BYTE_Reverse,
 
 		TXT2BYTE_END,
 };

--- a/Discovery/Src/data_central.c
+++ b/Discovery/Src/data_central.c
@@ -904,7 +904,7 @@ void clearCompassHeading(void) {
 
 void setCompassHeading(uint16_t heading)
 {
-    stateUsedWrite->diveSettings.compassHeading =  ((heading - 360) % 360) + 360;
+    stateUsedWrite->diveSettings.compassHeading = ((heading - 360) % 360) + 360;
 
     internalLogCompassHeading(heading, true, false);
 }

--- a/Discovery/Src/tMenuEditXtra.c
+++ b/Discovery/Src/tMenuEditXtra.c
@@ -358,6 +358,16 @@ static void openEdit_CO2Sensor()
 #endif
 
 
+static uint8_t OnAction_CompassHeadingReverse(uint32_t editId, uint8_t blockNumber, uint8_t digitNumber, uint8_t digitContent, uint8_t action)
+{
+    setCompassHeading((stateUsed->diveSettings.compassHeading + 180) % 360);
+
+    exitMenuEdit_to_Home_with_Menu_Update();
+
+    return EXIT_TO_HOME;
+}
+
+
 static uint8_t OnAction_CompassHeadingClear(uint32_t editId, uint8_t blockNumber, uint8_t digitNumber, uint8_t digitContent, uint8_t action)
 {
     clearCompassHeading();
@@ -396,6 +406,13 @@ static void drawCompassHeadingMenu(bool isRefresh)
     snprintf(text, 32, "\001%c%c", TXT_2BYTE, TXT2BYTE_CompassHeading);
     write_topline(text);
 
+    if (!isRefresh) {
+        snprintf(text, 32, "%c%c", TXT_2BYTE, TXT2BYTE_Set);
+        write_field_button(StMXTRA_CompassHeading, 20, 800, ME_Y_LINE1, &FontT48, text);
+    } else {
+        tMenuEdit_refresh_field(StMXTRA_CompassHeading);
+    }
+
     uint16_t heading;
     if (settings->compassInertia) {
         heading = (uint16_t)compass_getCompensated();
@@ -405,14 +422,18 @@ static void drawCompassHeadingMenu(bool isRefresh)
     snprintf(text,32,"\001%03i`",heading);
     write_label_var(0, 800, ME_Y_LINE1, &FontT54, text);
 
-    if (!isRefresh) {
-        snprintf(text, 32, "%c%c", TXT_2BYTE, TXT2BYTE_Set);
-        write_field_button(StMXTRA_CompassHeading, 20, 800, ME_Y_LINE2, &FontT48, text);
+    bool headingIsSet = stateUsed->diveSettings.compassHeading;
+    snprintf(text, 32, "%s%c%c", makeGrey(!headingIsSet), TXT_2BYTE, TXT2BYTE_Reverse);
+    if (headingIsSet) {
+        if (!isRefresh) {
+            write_field_button(StMXTRA_CompassHeadingReverse, 20, 800, ME_Y_LINE2, &FontT48, text);
+        } else {
+            tMenuEdit_refresh_field(StMXTRA_CompassHeadingReverse);
+        }
     } else {
-        tMenuEdit_refresh_field(StMXTRA_CompassHeading);
+        write_label_var(20, 800, ME_Y_LINE2, &FontT48, text);
     }
 
-    bool headingIsSet = stateUsed->diveSettings.compassHeading;
     snprintf(text, 32, "%s%c%c", makeGrey(!headingIsSet), TXT_2BYTE, TXT2BYTE_Clear);
     if (headingIsSet) {
         if (!isRefresh) {
@@ -451,6 +472,7 @@ static void drawCompassHeadingMenu(bool isRefresh)
 
     if (!isRefresh) {
         setEvent(StMXTRA_CompassHeading, (uint32_t)OnAction_CompassHeading);
+        setEvent(StMXTRA_CompassHeadingReverse, (uint32_t)OnAction_CompassHeadingReverse);
         setEvent(StMXTRA_CompassHeadingClear, (uint32_t)OnAction_CompassHeadingClear);
         setEvent(StMXTRA_CompassHeadingReset, (uint32_t)OnAction_CompassHeadingReset);
         setEvent(StMXTRA_CompassHeadingLog, (uint32_t)OnAction_CompassHeadingLog);

--- a/Discovery/Src/text_multilanguage.c
+++ b/Discovery/Src/text_multilanguage.c
@@ -1920,6 +1920,12 @@ static uint8_t text_FR_Log[] = "Enregistrer";
 static uint8_t text_IT_Log[] = "Registrare";
 static uint8_t text_ES_Log[] = "Registrar";
 
+static uint8_t text_EN_Reverse[] = "Reverse";
+static uint8_t text_DE_Reverse[] = "Umkehren";
+static uint8_t text_FR_Reverse[] = "Inverser";
+static uint8_t text_IT_Reverse[] = "Invertire";
+static uint8_t text_ES_Reverse[] = "Invertir";
+
 /* Lookup Table -------------------------------------------------------------*/
 
 const tText text_array[] =
@@ -2213,4 +2219,5 @@ const tText text_array2[] =
 
 	{(uint8_t)TXT2BYTE_Current, 	{text_EN_Current, text_DE_Current, text_FR_Current, text_IT_Current, text_ES_Current}},
 	{(uint8_t)TXT2BYTE_Log, 	{text_EN_Log, text_DE_Log, text_FR_Log, text_IT_Log, text_ES_Log}},
+	{(uint8_t)TXT2BYTE_Reverse, 	{text_EN_Reverse, text_DE_Reverse, text_FR_Reverse, text_IT_Reverse, text_ES_Reverse}},
 };


### PR DESCRIPTION
Add a 'Reverse' action to the compass heading dive menu.
This allows the compass heading to be reversed for the return leg of the
dive - as a bonus the reversal will be logged, establishing at which
point in the log the dive was turned.

![IMG_20250116_010856](https://github.com/user-attachments/assets/ae0689df-b68e-4d46-9b27-067c97f42fe9)
