### PR TITLE
Reorder the 'SYS' menus and fix a bug in 1.7.3.

### DIFF
--- a/Discovery/Src/tMenu.c
+++ b/Discovery/Src/tMenu.c
@@ -907,7 +907,7 @@ void openMenu(uint8_t freshWithFlipPages)
     change_CLUT_entry(CLUT_MenuLineSelectedSeperator, (CLUT_MenuPageGasOC + page - 1));
 
 
-    if(((page == 6) ||  (page == 8)) && (menu.pageCountNumber[page-1] == 0))
+    if(((page == 6) ||  (page == 9)) && (menu.pageCountNumber[page-1] == 0))
     {
         change_CLUT_entry(CLUT_MenuLineSelectedSides, 		(CLUT_MenuPageGasOC + page - 2));
         change_CLUT_entry(CLUT_MenuLineSelectedSeperator, (CLUT_MenuPageGasOC + page - 2));
@@ -1375,9 +1375,9 @@ static void draw_tMheader(uint8_t page)
         "DATA",
         "DECO",
         "",
-        "SYS",
         "",
-		"",
+        "",
+		"SYS",
 		"",
 		"SIM",
         ""


### PR DESCRIPTION
Reorder the 'SYS' menus so that they follow 'features / hardware /
display' which should be less confusing for users.

![IMG_20251012_183612](https://github.com/user-attachments/assets/40e821f4-e12f-40d3-9b18-f4c84bf644f5)


Also fix a bug with a non-implemented menu entry in the 'SYS1' menu on
OSTC4 leading to a hard lockup.

![ostc4_deadlock](https://github.com/user-attachments/assets/ffee58e0-23aa-4893-92ea-52de5f97c026)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Adjusted menu color palette adjustments to ensure consistent display across different pages.
  * Reorganized system tab positioning in the menu header for improved visual alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
