### PR TITLE
Add 'install' target to the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,19 @@ SCRIPT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 BUILD_DIR ?= $(SCRIPT_DIR)
 export BUILD_DIR
 
+FIRMWARE_INSTALLER := subsurface-downloader
+
+INSTALL_TARGET := firmware
+MODEL := "OSTC 4/5"
+DEVICE := /dev/rfcomm0
+FORCE :=
+
 NUM_CORES := $(shell \
   command -v nproc >/dev/null 2>&1 && nproc || \
   getconf _NPROCESSORS_ONLN 2>/dev/null || \
   sysctl -n hw.ncpu 2>/dev/null || echo 1)
 
+MAKEFLAGS += j$(NUM_CORES)
 # Default target
 
 firmware: firmware_binary packer
@@ -23,22 +31,28 @@ all: firmware_binary fontpack_binary rte_binary packer
 	ostc4pack/create_full_update_bin.sh --version
 
 fontpack_library: arm_tools_install
-	$(MAKE) -C RefPrj/FontPack/Library -f Makefile -j $(NUM_CORES)
+	$(MAKE) -C RefPrj/FontPack/Library -f Makefile
 
 firmware_binary: arm_tools_install fontpack_library
-	$(MAKE) -C RefPrj/Firmware/Release -f Makefile -j $(NUM_CORES)
+	$(MAKE) -C RefPrj/Firmware/Release -f Makefile
 
 fontpack_binary: arm_tools_install fontpack_library
-	$(MAKE) -C RefPrj/FontPack/Release -f Makefile -j $(NUM_CORES)
+	$(MAKE) -C RefPrj/FontPack/Release -f Makefile
 
 rte_binary: arm_tools_install fontpack_library
-	$(MAKE) -C RefPrj/RTE/Release -f Makefile -j $(NUM_CORES)
+	$(MAKE) -C RefPrj/RTE/Release -f Makefile
 
 print_version:
 	@ostc4pack/create_full_update_bin.sh --version --no-date --print-version-only
 
+install: $(INSTALL_TARGET)
+	$(eval VERSION := $(shell ostc4pack/create_full_update_bin.sh --version --no-date --print-version-only))
+	$(eval DATE := $(shell date +%Y%m%d))
+	$(eval FILENAME := "Release/OSTC4update_$(INSTALL_TARGET)_$(VERSION)_$(DATE).bin")
+	$(FIRMWARE_INSTALLER) --update-firmware --dc-vendor="Heinrichs Weikamp" --dc-product=$(MODEL) --device=$(DEVICE) $(if $(FORCE),--force-update-firmware) --firmware-file=$(FILENAME)
+
 packer:
-	$(MAKE) -C ostc4pack/src -j $(NUM_CORES)
+	$(MAKE) -C ostc4pack/src
 
 packer_clean:
 	$(MAKE) -C ostc4pack/src clean
@@ -50,11 +64,12 @@ clean:
 	$(MAKE) -C RefPrj/RTE/Release -f Makefile clean
 	$(RM) -f Release/OSTC4_Firmware*.bin Release/OSTC4_FontPack*.bin Release/OSTC4_RTE*.bin
 
-distclean: clean packer_clean
+distclean:: clean packer_clean
+	$(RM) -f Release/OSTC4update_*.bin
 
 test:
 	@echo "No tests defined"
 
 include arm_build_tools.mk
 
-.PHONY: firmware fontpack rte fontpack_library firmware_binary fontpack_binary rte_binary all clean print_version packer packer_clean distclean test
+.PHONY: firmware fontpack rte fontpack_library firmware_binary fontpack_binary rte_binary all install clean print_version packer packer_clean distclean test

--- a/arm_build_tools.mk
+++ b/arm_build_tools.mk
@@ -56,7 +56,7 @@ arm_tools_version:
 arm_tools_uninstall:
 	$(RM) -rf "$(TOOLCHAIN_DIR)"
 
-distclean: arm_tools_uninstall
+distclean:: arm_tools_uninstall
 	$(RM) -rf "$(BUILD_TOOLS_DIR)/dist"
 
 .PHONY: arm_tools_install arm_tools_version arm_tools_uninstall distclean

--- a/ostc4pack/README.linux
+++ b/ostc4pack/README.linux
@@ -10,15 +10,15 @@ make OSTC4pack_V4
 2. Edit create_full_update_bin.sh
 
 Set BUILD_PATH to the location where you build the individual parts
-of the firmware using the OpenSTM23 IDE. 
+of the firmware using the OpenSTM32 IDE.
 
-Set BUILD_TYPE the either Debug or Release (or any other build style you 
-defined in the OpenSTM23 IDE).
+Set BUILD_TYPE to either Debug or Release (or any other build style you
+defined in the OpenSTM32 IDE).
 
-Set the "build project names" as defined in the OpenSTM23 IDE.
+Set the "build project names" as defined in the OpenSTM32 IDE.
 
 3. Simpy run create_full_update_bin.sh
 
 Run it in the ostc4pack folder of the repository, and a file with name
-like OSTC4_<date>.bin is created containg the individual blobs.
+like <build type>/OSTC4update_<target>_<version>_<date>.bin is created containing the individual blobs.
 

--- a/ostc4pack/src/checksum_final_add_fletcher.cpp
+++ b/ostc4pack/src/checksum_final_add_fletcher.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
 		if (useVersion || !printVersionOnly) {
 			index += sprintf(&versionName[index], "_");
 		}
-		index += sprintf(&versionName[index], "%02u%02u%02u", timeinfo->tm_year-100, timeinfo->tm_mon + 1, timeinfo->tm_mday);
+		index += sprintf(&versionName[index], "%04u%02u%02u", timeinfo->tm_year + 1900, timeinfo->tm_mon + 1, timeinfo->tm_mday);
 	}
 
 	if (printVersionOnly) {


### PR DESCRIPTION
Signed-off-by: Michael Keller <github@ike.ch>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a firmware installation workflow that auto-generates version/date metadata and exposes install-related settings.

* **Bug Fixes**
  * Fixed version date formatting to use a 4-digit year.

* **Chores**
  * Enabled parallel build support and adjusted several build invocation behaviors.
  * Expanded cleanup to remove generated firmware update files and updated clean targets.

* **Documentation**
  * Clarified packaging guide examples and IDE references; updated example output filename/path format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->