### PR TITLE
Add an Option to Build without Firmware.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,19 @@
-SCRIPT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+# Command line settings
 
-BUILD_DIR ?= $(SCRIPT_DIR)
-export BUILD_DIR
-
-FIRMWARE_INSTALLER := subsurface-downloader
+# Don't build the firmware by setting NO_FIRMWARE
 
 # For the 'install' target
 BUILD_TYPE := firmware
 MODEL := "OSTC 4/5"
 DEVICE := /dev/rfcomm0
 FORCE :=
+
+SCRIPT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+
+BUILD_DIR ?= $(SCRIPT_DIR)
+export BUILD_DIR
+
+FIRMWARE_INSTALLER := subsurface-downloader
 
 NUM_CORES := $(shell \
   command -v nproc >/dev/null 2>&1 && nproc || \
@@ -22,11 +26,23 @@ MAKEFLAGS += j$(NUM_CORES)
 firmware: firmware_binary packer
 	ostc4pack/create_full_update_bin.sh --version --no-rte --no-fonts
 
+ifdef NO_FIRMWARE
+
+fontpack: fontpack_binary packer
+	ostc4pack/create_full_update_bin.sh --version --no-rte --no-firmware
+
+rte: rte_binary packer
+	ostc4pack/create_full_update_bin.sh --version --no-fonts --no-firmware
+
+else
+
 fontpack: firmware_binary fontpack_binary packer
 	ostc4pack/create_full_update_bin.sh --version --no-rte
 
 rte: firmware_binary rte_binary packer
 	ostc4pack/create_full_update_bin.sh --version --no-fonts
+
+endif
 
 bootloader: bootloader_binary packer
 	ostc4pack/create_full_update_bin.sh --version --no-rte --no-fonts --do-bootloader

--- a/ostc4pack/create_full_update_bin.sh
+++ b/ostc4pack/create_full_update_bin.sh
@@ -36,6 +36,11 @@ while test $# -gt 0; do
         shift
 
         ;;
+    --no-firmware)
+        NO_FIRMWARE=1
+        shift
+
+        ;;
     --do-bootloader)
         DO_BOOTLOADER=1
         TYPE="bootloader"
@@ -58,7 +63,7 @@ while test $# -gt 0; do
 
         ;;
     *)
-        echo "Invalid parameter. Usage: create_full_update_bin.sh [--no-fonts] [--no-rte] [--no-date]"
+        echo "Invalid parameter. Usage: create_full_update_bin.sh [--no-fonts] [--no-rte] [--no-firmware] [--no-date] [--version] [--print-version-only] [--do-bootloader]"
         exit 1
 
         ;;
@@ -95,7 +100,7 @@ fi
 mkdir -p ./$BUILD_TYPE
 cd ./$BUILD_TYPE
 
-if [ -z "${DO_BOOTLOADER:+x}" ]; then
+if [ -z "${NO_FIRMWARE:+x}" ]; then
     pushd $BUILD_PATH/$CPU1_DISCOVERY/$BUILD_TYPE/
     $PACKAGE_TOOL_DIR/OSTC4pack_V4 1 ${PROJECT_NAME_PREFIX}${CPU1_DISCOVERY}.bin
     CHECKSUM_COMMAND_PARAMETERS="${CHECKSUM_COMMAND_PARAMETERS} $(pwd)/${PROJECT_NAME_PREFIX}${CPU1_DISCOVERY}_upload.bin"


### PR DESCRIPTION
Signed-off-by: Michael Keller <github@ike.ch>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --no-firmware option to build packaging artifacts without firmware components.
  * Added public build targets for full packaging, fontpack, runtime, firmware binaries, and installation sequencing.

* **Chores**
  * Improved CPU core detection for faster parallel builds.
  * Reorganized build variable and conditional layout to cleanly separate firmware inclusion from other packaging steps.
* **Maintenance**
  * Preserved bootloader handling and expanded clean/distclean entry points.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->