### PR TITLE
Add Full Reset for the Stollmann Bluetooth Module."

### DIFF
--- a/BootLoader/Src/base_bootlader.c
+++ b/BootLoader/Src/base_bootlader.c
@@ -445,9 +445,7 @@ GPIO_test_I2C_lines();
 		i = 0;
 	}
 	else
-	if(			(firmware_MainCodeIsProgammed() == 0)
-			||	(HardwareData->primarySerial == 0xFFFF)
-			||	(HardwareData->production_bluetooth_name_set == 0xFF))
+	if(			(firmware_MainCodeIsProgammed() == 0))
 	{
 		i = 1;
 	}
@@ -679,10 +677,6 @@ GPIO_test_I2C_lines();
 	TIM_init();
 	MX_UART_Init();
 
-	/* Recovery: try to reconfigure a factory-reset Bluetooth module */
-	tComm_RecoverBluetoothModule();
-
-	/* Don't power cycle Bluetooth - connection may already be established from firmware */
 	MX_Bluetooth_PowerOn();
 
 	tComm_init();

--- a/BootLoader/Src/base_bootlader.c
+++ b/BootLoader/Src/base_bootlader.c
@@ -679,6 +679,9 @@ GPIO_test_I2C_lines();
 	TIM_init();
 	MX_UART_Init();
 
+	/* Recovery: try to reconfigure a factory-reset Bluetooth module */
+	tComm_RecoverBluetoothModule();
+
 	/* Don't power cycle Bluetooth - connection may already be established from firmware */
 	MX_Bluetooth_PowerOn();
 

--- a/BootLoader/Src/base_bootlader.c
+++ b/BootLoader/Src/base_bootlader.c
@@ -445,7 +445,9 @@ GPIO_test_I2C_lines();
 		i = 0;
 	}
 	else
-	if(			(firmware_MainCodeIsProgammed() == 0))
+	if(			(firmware_MainCodeIsProgammed() == 0)
+			|| (HardwareData->primarySerial == 0xFFFF)
+			|| (HardwareData->production_bluetooth_name_set == 0xFF))
 	{
 		i = 1;
 	}

--- a/BootLoader/Src/ostc_mini.c
+++ b/BootLoader/Src/ostc_mini.c
@@ -408,13 +408,16 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
 
 /**
  * Called by HAL when a UART error (ORE, FE, NE, PE) occurs during IT receive.
- * ORE (overrun) aborts the IT receive silently; we must restart it.
+ * Note: This callback currently has no effect because the bootloader now uses
+ * polling-based UART receive (not interrupt-based) in tComm_control().
+ * The StartListeningToUART flag is set but not checked in the polling implementation.
+ * This callback is kept for compatibility but may be removed in the future.
  */
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
 {
     if(huart == &UartHandle)
     {
-        /* Signal main loop to restart HAL_UART_Receive_IT */
+        /* Flag is no longer used in polling-based implementation */
         StartListeningToUART = 1;
     }
 }

--- a/BootLoader/Src/ostc_mini.c
+++ b/BootLoader/Src/ostc_mini.c
@@ -45,6 +45,8 @@ UART_HandleTypeDef UartIR_HUD_Handle;
 __IO ITStatus UartReady = RESET;
 __IO ITStatus UartReadyHUD = RESET;
 
+extern uint8_t StartListeningToUART;  /* defined in tComm_mini.c */
+
 /* Private types -------------------------------------------------------------*/
 
 /* Private variables ---------------------------------------------------------*/
@@ -347,11 +349,11 @@ void MX_UART_Init(void)
       - BaudRate = 115200 baud
       - Hardware flow control: RTS/CTS for old module */
 
-#ifdef USARTx_CTS_PIN
-    UartHandle.Init.HwFlowCtl  = UART_HWCONTROL_RTS_CTS;
-#else
+    /* Original bootloader: no hardware flow control.
+     * PA11/PA12 are NOT configured as AF in stm32f4xx_hal_msp_hw1.c
+     * (USART1_CTS_PIN is not defined). The UART transmits freely and
+     * the module's FC is handled by external pin levels. */
     UartHandle.Init.HwFlowCtl  = UART_HWCONTROL_NONE;
-#endif
     UartHandle.Instance        = USARTx;
     UartHandle.Init.BaudRate   = 115200;
     UartHandle.Init.WordLength = UART_WORDLENGTH_8B;
@@ -400,6 +402,20 @@ void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart)
     if(huart == &UartIR_HUD_Handle)
     {
 		UartReadyHUD = SET;
+    }
+}
+
+
+/**
+ * Called by HAL when a UART error (ORE, FE, NE, PE) occurs during IT receive.
+ * ORE (overrun) aborts the IT receive silently; we must restart it.
+ */
+void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart)
+{
+    if(huart == &UartHandle)
+    {
+        /* Signal main loop to restart HAL_UART_Receive_IT */
+        StartListeningToUART = 1;
     }
 }
 

--- a/BootLoader/Src/tComm_mini.c
+++ b/BootLoader/Src/tComm_mini.c
@@ -116,7 +116,6 @@ static BlueModTmpConfig_t BmTmpConfig = BM_CONFIG_OFF;	/* Config BlueMod without
 static uint8_t EvaluateBluetoothSignalStrength = 0;
 
 /* Private function prototypes -----------------------------------------------*/
-static void tComm_Error_Handler(void);
 static uint8_t select_mode(uint8_t aRxByte);
 static uint8_t tComm_CheckAnswerOK(void);
 static uint8_t tComm_HandleBlueModConfig(void);
@@ -540,7 +539,7 @@ void tComm_exit(void)
     {
     	set_globalState_Base();
     }
-    MX_Bluetooth_PowerOff();						// Power down Bluetooth on the way out
+    /* Keep Bluetooth powered while bootloader runs */
 }
 
 
@@ -877,6 +876,7 @@ uint8_t select_mode(uint8_t type)
 
         case 0x82:
             setForcedBluetoothName = 1;
+            set_returnFromComm();
             return 0;
 
         case 0x74:
@@ -917,23 +917,31 @@ uint8_t select_mode(uint8_t type)
         case 0x80:
             if(HAL_UART_Receive(&UartHandle, (uint8_t*)aRxBuffer,  52, 5000)!= HAL_OK)
                 return 0;
-            if(hardware_programmProductionData(aRxBuffer) == HAL_OK)
             {
-                aTxBuffer[count++] = prompt4D4C(receiveStartByteUart);
+                uint8_t prog = hardware_programmProductionData(aRxBuffer);
+                /* 0xE0 means data already programmed; keep comm alive. */
+                if((prog == HAL_OK) || (prog == 0xE0))
+                {
+                    aTxBuffer[count++] = prompt4D4C(receiveStartByteUart);
+                }
+                else
+                    return 0;
             }
-            else
-                return 0;
             break;
 
         case 0x81:
             if(HAL_UART_Receive(&UartHandle, (uint8_t*)aRxBuffer,  12, 1000)!= HAL_OK)
                 return 0;
-            if(hardware_programmSecondarySerial(aRxBuffer) == HAL_OK)
             {
-                aTxBuffer[count++] = prompt4D4C(receiveStartByteUart);
+                uint8_t prog = hardware_programmSecondarySerial(aRxBuffer);
+                /* 0xE0 means data already programmed; keep comm alive. */
+                if((prog == HAL_OK) || (prog == 0xE0))
+                {
+                    aTxBuffer[count++] = prompt4D4C(receiveStartByteUart);
+                }
+                else
+                    return 0;
             }
-            else
-                return 0;
             break;
 
         }
@@ -2351,10 +2359,4 @@ uint8_t tComm_HandleBlueModConfig()
 		}
 	}
 	return result;
-}
-
-static void tComm_Error_Handler(void)
-{
-  while(1)
-  {}
 }

--- a/BootLoader/Src/tComm_mini.c
+++ b/BootLoader/Src/tComm_mini.c
@@ -322,6 +322,7 @@ uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence)
     uint8_t answer = HAL_OK;
     uint8_t aRxBuffer[50];
     char aTxBufferName[50];
+    char aTxBufferBLEName[50];
 
 //	char aTxFactoryDefaults[50] = "AT&F1\r";
 
@@ -334,6 +335,11 @@ uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence)
     char answerOkay[6] = "\r\nOK\r\n";
 
     gfx_number_to_string(5,1,&aTxBufferName[15],serial);
+
+    // For Stollmann module: prepare BLE name command using proper enum
+    // This ensures the correct AT command is sent for each module type
+    tComm_GetBTCmdStr(BT_CMD_BLE_NAME, aTxBufferBLEName);
+    gfx_number_to_string(5,1,&aTxBufferBLEName[15],serial);
 
     // store active configuration in non-volatile memory
     char aTxBufferWrite[50] = "AT&W\r";
@@ -355,6 +361,7 @@ uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence)
             answer = HAL_ERROR;
     }
 
+    // Send classic BT name command (AT+BNAME=OSTC4-xxxxx)
     aRxBuffer[0] = 0;
     if(HAL_UART_Transmit(&UartHandle, (uint8_t*)aTxBufferName, 21, 2000)!= HAL_OK)
         answer = HAL_ERROR;
@@ -370,6 +377,23 @@ uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence)
 
     HAL_Delay(200);
 
+    // Send BLE name command (AT+UBTLN=OSTC4-xxxxx)
+    aRxBuffer[0] = 0;
+    if(HAL_UART_Transmit(&UartHandle, (uint8_t*)aTxBufferBLEName, 21, 2000)!= HAL_OK)
+        answer = HAL_ERROR;
+    HAL_UART_Receive(&UartHandle, (uint8_t*)aRxBuffer, 21+6, 2000);
+
+    for(int i=0;i<21;i++)
+    if(aRxBuffer[i] != aTxBufferBLEName[i])
+        answer = HAL_ERROR;
+
+    for(int i=0;i<6;i++)
+    if(aRxBuffer[21+i] != answerOkay[i])
+        answer = HAL_ERROR;
+
+    HAL_Delay(200);
+
+    // Store both names in non-volatile memory (AT&W)
     if(HAL_UART_Transmit(&UartHandle, (uint8_t*)aTxBufferWrite, 5, 2000)!= HAL_OK)
         answer = HAL_ERROR;
     HAL_UART_Receive(&UartHandle, (uint8_t*)aRxBuffer, 5+6, 2000);
@@ -1732,6 +1756,9 @@ uint8_t tComm_GetBTCmdStr(BTCmd cmdId, char* pCmdStr)
 			case BT_CMD_NAME:			strcpy(pCmdStr,"AT+BNAME=OSTC4-12345\r");
 										ret = 1;
 				break;
+			case BT_CMD_BLE_NAME:		strcpy(pCmdStr,"AT+UBTLN=OSTC4-12345\r");
+									ret = 1;
+				break;
 			case BT_CMD_EXIT_CMD:		strcpy(pCmdStr,"ATO\r");
 										ret = 1;
 				break;
@@ -1754,9 +1781,9 @@ uint8_t tComm_GetBTCmdStr(BTCmd cmdId, char* pCmdStr)
 			case BT_CMD_NAME:			strcpy(pCmdStr,"AT+UBTLN=OSTC5-12345\r");
 										ret = 1;
 				break;
-			case BT_CMD_EXIT_CMD:		strcpy(pCmdStr,"ATO1\r");
-										ret = 1;
-				break;
+		case BT_CMD_BLE_NAME:		strcpy(pCmdStr,"AT+UBTLN=OSTC5-12345\r");
+									ret = 1;
+			break;
 			default:
 				break;
 		}
@@ -1828,6 +1855,8 @@ uint8_t tComm_HandleBlueModConfig()
 	if(time_elapsed_ms(cmdStartTick, HAL_GetTick()) > 100)
 	{
 		cmdStartTick = HAL_GetTick();
+        /* Clear first byte to avoid re-sending stale commands when a step is skipped */
+        TxBuffer[0] = 0;
 		switch (BmTmpConfig)
 		{
 			case BM_CONFIG_ECHO: 			tComm_GetBTCmdStr (BT_CMD_ECHO, TxBuffer);
@@ -1938,24 +1967,28 @@ uint8_t tComm_HandleBlueModConfig()
 					break;
 				case BM_INIT_FACTORY:		sprintf(TxBuffer,"AT&F1\r");      /* Stollmann: Factory reset */
 										break;
-				case BM_INIT_MODE:			BmTmpConfig++;
+                case BM_INIT_MODE:			TxBuffer[0] = 0; /* Stollmann: No mode command needed, skip this step */
+                                        break;
+                case BM_INIT_BLE:			TxBuffer[0] = 0; /* Stollmann: Skip, will use UBTLN after BNAME */
+                                        break;
+                case BM_INIT_NAME:			sprintf(TxBuffer,"AT+BNAME=OSTC4-12345\r"); /* Stollmann: Classic Bluetooth name */
+                                        if(hardwareDataGetPointer()->primarySerial != 0xFFFF)
+                                        {
+                                            gfx_number_to_string(5,1,&TxBuffer[15],hardwareDataGetPointer()->primarySerial);
+                                            hardware_programmPrimaryBluetoothNameSet();
+                                        }
 										break;
-				case BM_INIT_BLE:			BmTmpConfig++;
+                case BM_INIT_SSP_IDO_OFF:	sprintf(TxBuffer,"AT+UBTLN=OSTC4-12345\r"); /* Stollmann: BLE Device Name (after classic name) */
+                                        if(hardwareDataGetPointer()->primarySerial != 0xFFFF)
+                                        {
+                                            gfx_number_to_string(5,1,&TxBuffer[15],hardwareDataGetPointer()->primarySerial);
+                                        }
+                                        break;
+                case BM_INIT_SSP_IDO_ON:	TxBuffer[0] = 0; /* Stollmann: No SSP command needed, skip */
+                                        break;
+				case BM_INIT_SSP_ID1_OFF:	TxBuffer[0] = 0; /* Stollmann: No SSP command needed, skip */
 										break;
-				case BM_INIT_NAME:			sprintf(TxBuffer,"AT+BNAME=OSTC4-12345\r"); /* Stollmann: Bluetooth name */
-											if(hardwareDataGetPointer()->primarySerial != 0xFFFF)
-											{
-												gfx_number_to_string(5,1,&TxBuffer[15],hardwareDataGetPointer()->primarySerial);
-												hardware_programmPrimaryBluetoothNameSet();
-											}
-										break;
-				case BM_INIT_SSP_IDO_OFF:	BmTmpConfig++;
-										break;
-				case BM_INIT_SSP_IDO_ON:	BmTmpConfig++;
-										break;
-				case BM_INIT_SSP_ID1_OFF:	BmTmpConfig++;
-										break;
-				case BM_INIT_SSP_ID1_ON:	BmTmpConfig++;
+				case BM_INIT_SSP_ID1_ON:	TxBuffer[0] = 0; /* Stollmann: No SSP command needed, skip */
 										break;
 				case BM_INIT_STORE:			sprintf(TxBuffer,"AT&W\r");	      /* Stollmann: Write settings to EEPROM */
 										break;

--- a/BootLoader/Src/tComm_mini.c
+++ b/BootLoader/Src/tComm_mini.c
@@ -131,6 +131,7 @@ static uint8_t openComm(uint8_t aRxByte);
 uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence);
 uint8_t prompt4D4C(uint8_t mode);
 uint8_t tComm_GetBTCmdStr(BTCmd cmdId, char* pCmdStr);
+void tComm_RecoverBluetoothModule(void);
 
 
 static uint8_t receive_update_data_cpu2(void);
@@ -157,6 +158,252 @@ void tComm_init(void)
     tCwindow.WindowY1 = 479;
 
     StartListeningToUART = 1;
+}
+
+/* Debug structure to track Bluetooth recovery attempts - visible via ST-Link */
+typedef struct {
+    uint32_t current_baud_rate;
+    uint8_t baud_index;
+    uint8_t cmd_index;
+    uint8_t response_received;
+    uint8_t response_buffer[32];
+    uint8_t response_length;
+    uint32_t working_baud_found;
+    uint8_t state;  /* 0=idle, 1=testing, 2=found_working, 3=setting_baud, 4=saving, 5=failed */
+    uint32_t power_cycle_count;
+    uint8_t last_test_baud_rates[15];  /* indices of tested baud rates */
+    uint8_t last_test_responses[15];   /* response flags: 0=no resp, 1=got response, 2=got OK */
+} BT_RecoveryDebug_t;
+
+/* Make this global so GDB can inspect it */
+BT_RecoveryDebug_t bt_debug = {0};
+
+/**
+ * Assert RTS (PA12) LOW as a regular GPIO output.
+ * This tells the Bluetooth module it's OK to transmit.
+ * Needed when UART flow control is disabled on the MCU side but the module
+ * still has flow control enabled (e.g. after AT&F1 factory reset).
+ */
+static void tComm_AssertRTS(void)
+{
+    GPIO_InitTypeDef gpio;
+    gpio.Pin   = GPIO_PIN_12;  /* PA12 = USART1_RTS */
+    gpio.Mode  = GPIO_MODE_OUTPUT_PP;
+    gpio.Pull  = GPIO_NOPULL;
+    gpio.Speed = GPIO_SPEED_FAST;
+    HAL_GPIO_Init(GPIOA, &gpio);
+    HAL_GPIO_WritePin(GPIOA, GPIO_PIN_12, GPIO_PIN_RESET);  /* LOW = RTS active */
+}
+
+/**
+ * Try to get a response from the BT module at the current UART settings.
+ * Sends cmd, waits up to timeout_ms for any data back.
+ * Returns number of bytes received (0 = no response).
+ */
+static uint8_t tComm_ProbeModule(const char* cmd, uint8_t* rxBuf, uint16_t timeout_ms)
+{
+    uint8_t index = 0;
+    uint32_t start_tick;
+
+    /* Flush stale RX data */
+    start_tick = HAL_GetTick();
+    while ((HAL_GetTick() - start_tick) < 100)
+        HAL_UART_Receive(&UartHandle, &rxBuf[0], 1, 5);
+
+    /* Send command */
+    if (HAL_UART_Transmit(&UartHandle, (uint8_t*)cmd, strlen(cmd), 500) != HAL_OK)
+        return 0;
+
+    HAL_Delay(200);  /* Let module process */
+
+    /* Collect response */
+    memset(rxBuf, 0, UART_CMD_BUF_SIZE);
+    start_tick = HAL_GetTick();
+    while ((HAL_GetTick() - start_tick) < timeout_ms && index < UART_CMD_BUF_SIZE)
+    {
+        if (HAL_UART_Receive(&UartHandle, &rxBuf[index], 1, 30) == HAL_OK)
+            index++;
+    }
+    return index;
+}
+
+/**
+ * Initialise UART at given baud rate with flow control disabled,
+ * then manually assert RTS so the module can respond.
+ */
+static HAL_StatusTypeDef tComm_InitUartNoFC(uint32_t baud)
+{
+    HAL_StatusTypeDef rc;
+    UartHandle.Init.HwFlowCtl = UART_HWCONTROL_NONE;
+    UartHandle.Init.BaudRate  = baud;
+    rc = HAL_UART_Init(&UartHandle);
+    if (rc == HAL_OK)
+        tComm_AssertRTS();   /* PA12 LOW so module sees CTS# active */
+    return rc;
+}
+
+void tComm_RecoverBluetoothModule(void)
+{
+    uint8_t RxBuffer[UART_CMD_BUF_SIZE];
+    uint8_t rxLen;
+    uint8_t recovery_success = 0;
+    uint32_t working_baud = 0;
+    uint8_t saved_flow_control;
+
+    bt_debug.state = 1;  /* testing */
+    bt_debug.power_cycle_count = 0;
+    memset(bt_debug.last_test_baud_rates, 0xFF, sizeof(bt_debug.last_test_baud_rates));
+    memset(bt_debug.last_test_responses, 0, sizeof(bt_debug.last_test_responses));
+
+    saved_flow_control = UartHandle.Init.HwFlowCtl;
+
+    /* Baud rates to try – factory default 115200 first */
+    const uint32_t baud_rates[] = {
+        115200, 9600, 460800, 38400, 19200,
+        57600, 230400, 4800, 2400, 1200,
+        921600, 14400, 28800, 76800, 153600
+    };
+    const uint8_t num_baud_rates = sizeof(baud_rates) / sizeof(baud_rates[0]);
+
+    /* ---- Power cycle ---- */
+    MX_Bluetooth_PowerOff();
+    bt_debug.power_cycle_count++;
+    HAL_Delay(3000);
+    MX_Bluetooth_PowerOn();
+    HAL_Delay(4000);   /* Module datasheet: ~2 s boot time */
+
+    /* ---- Phase 1: try WITH hardware flow control at 115200 ----
+     * After AT&F1 factory reset, Stollmann defaults to 115200 + RTS/CTS.
+     * With proper AF pins (fixed ifdef in MspInit), both sides should talk. */
+    UartHandle.Init.HwFlowCtl = UART_HWCONTROL_RTS_CTS;
+    UartHandle.Init.BaudRate  = 115200;
+    if (HAL_UART_Init(&UartHandle) == HAL_OK)
+    {
+        bt_debug.current_baud_rate = 115200;
+        bt_debug.baud_index = 0;
+        bt_debug.last_test_baud_rates[0] = 0;
+
+        rxLen = tComm_ProbeModule("AT\r", RxBuffer, 1000);
+        if (rxLen >= 2)
+        {
+            recovery_success = 1;
+            working_baud = 115200;
+            bt_debug.last_test_responses[0] = 2;
+        }
+    }
+
+    /* ---- Phase 2: scan all baud rates WITHOUT flow control,
+     *               but manually assert RTS (PA12 LOW) so the module's
+     *               CTS# input is satisfied and it can transmit. ---- */
+    for (uint8_t baud_idx = 0; baud_idx < num_baud_rates && !recovery_success; baud_idx++)
+    {
+        bt_debug.baud_index = baud_idx;
+        bt_debug.current_baud_rate = baud_rates[baud_idx];
+        bt_debug.last_test_baud_rates[baud_idx] = baud_idx;
+
+        if (tComm_InitUartNoFC(baud_rates[baud_idx]) != HAL_OK)
+            continue;
+
+        HAL_Delay(100);
+
+        /* Try several AT commands */
+        const char* test_cmds[] = { "AT\r", "ATE0\r", "ATI\r", "+++" };
+        for (uint8_t cmd_idx = 0; cmd_idx < 4 && !recovery_success; cmd_idx++)
+        {
+            bt_debug.cmd_index = cmd_idx;
+            bt_debug.response_received = 0;
+
+            rxLen = tComm_ProbeModule(test_cmds[cmd_idx], RxBuffer, 1000);
+            if (rxLen > 0)
+            {
+                bt_debug.response_received = 1;
+                bt_debug.last_test_responses[baud_idx] = 1;
+                memcpy(bt_debug.response_buffer, RxBuffer,
+                       rxLen < 32 ? rxLen : 32);
+                bt_debug.response_length = rxLen < 32 ? rxLen : 32;
+            }
+            if (rxLen >= 2)
+            {
+                recovery_success = 1;
+                working_baud = baud_rates[baud_idx];
+                bt_debug.last_test_responses[baud_idx] = 2;
+            }
+        }
+    }
+
+    /* ---- Phase 3: additional power cycles at common rates ---- */
+    for (uint8_t cycle = 0; cycle < 2 && !recovery_success; cycle++)
+    {
+        bt_debug.power_cycle_count++;
+        MX_Bluetooth_PowerOff();
+        HAL_Delay(2000);
+        MX_Bluetooth_PowerOn();
+        HAL_Delay(3000);
+
+        const uint32_t retry_rates[] = { 115200, 9600, 460800 };
+        for (uint8_t i = 0; i < 3 && !recovery_success; i++)
+        {
+            if (tComm_InitUartNoFC(retry_rates[i]) != HAL_OK)
+                continue;
+
+            bt_debug.current_baud_rate = retry_rates[i];
+            rxLen = tComm_ProbeModule("AT\r", RxBuffer, 1000);
+            if (rxLen >= 2)
+            {
+                recovery_success = 1;
+                working_baud = retry_rates[i];
+            }
+        }
+    }
+
+    /* ---- Apply configuration if we found the module ---- */
+    if (recovery_success && working_baud != 0)
+    {
+        bt_debug.state = 2;  /* found_working */
+        bt_debug.working_baud_found = working_baud;
+
+        /* Re-init at working baud (no FC + RTS asserted) if not already */
+        tComm_InitUartNoFC(working_baud);
+        HAL_Delay(100);
+
+        /* 1. Disable flow control on the module (Stollmann: AT\Q0) */
+        tComm_ProbeModule("AT\\Q0\r", RxBuffer, 500);
+        HAL_Delay(100);
+
+        /* 2. Set baud rate to 115200 if needed (Stollmann: AT%B8) */
+        if (working_baud != 115200)
+        {
+            bt_debug.state = 3;  /* setting_baud */
+            tComm_ProbeModule("AT%B8\r", RxBuffer, 500);
+            HAL_Delay(300);
+
+            /* Switch MCU to 115200 */
+            tComm_InitUartNoFC(115200);
+            HAL_Delay(200);
+        }
+
+        /* 3. Turn off echo */
+        tComm_ProbeModule("ATE0\r", RxBuffer, 300);
+
+        /* 4. Save to NVM */
+        bt_debug.state = 4;  /* saving */
+        tComm_ProbeModule("AT&W\r", RxBuffer, 500);
+        HAL_Delay(200);
+
+        /* Verify we can still talk after save */
+        rxLen = tComm_ProbeModule("AT\r", RxBuffer, 500);
+        if (rxLen < 2)
+            bt_debug.state = 5;  /* save may have failed */
+    }
+    else
+    {
+        bt_debug.state = 5;  /* failed – no response at any baud rate */
+    }
+
+    /* Restore UART to normal operating config */
+    UartHandle.Init.BaudRate  = 115200;
+    UartHandle.Init.HwFlowCtl = saved_flow_control;
+    HAL_UART_Init(&UartHandle);
 }
 
 uint8_t tComm_control(void)

--- a/BootLoader/Src/tComm_mini.c
+++ b/BootLoader/Src/tComm_mini.c
@@ -420,87 +420,22 @@ uint8_t tComm_control(void)
     else
     {
     /*##-2- Put UART peripheral in reception process ###########################*/
-		static uint8_t listeningMsgShown = 0;
-		static uint8_t rxByteCount = 0;
-		static uint8_t diagBuf[8];
-		static uint8_t diagLen = 0;
-		static uint8_t lastCTS = 0xFF;
-		static uint16_t pollCount = 0;
 
-		if(!listeningMsgShown)
+		if((UartReady == RESET) && StartListeningToUART)
 		{
-			if(UartHandle.Init.BaudRate == 460800)
-				tInfo_write("Listen 460k");
-			else
-				tInfo_write("Listen 115k");
-			listeningMsgShown = 1;
+				StartListeningToUART = 0;
+				receiveStartByteUart = 0;
+				if(HAL_UART_Receive_IT(&UartHandle, &receiveStartByteUart, 1) != HAL_OK)
+						tComm_Error_Handler();
 		}
-
-		/* Monitor CTS (PA11 = module RTS#) for state changes.
-		 * If it transitions, the module is signaling something. */
+		/* Reset transmission flag */
+		if(UartReady == SET)
 		{
-			uint8_t cts = HAL_GPIO_ReadPin(GPIOA, GPIO_PIN_11);
-			if(cts != lastCTS)
-			{
-				lastCTS = cts;
-				if(cts == GPIO_PIN_SET)
-					tInfo_write("CTS->1");
-				else
-					tInfo_write("CTS->0");
-			}
-		}
-
-		/* Show poll count every 20 iterations (~10s) as heartbeat */
-		pollCount++;
-		if(pollCount % 20 == 0)
-		{
-			char hb[12];
-			hb[0] = '#';
-			uint16_t v = pollCount;
-			hb[1] = '0' + (v / 10000) % 10;
-			hb[2] = '0' + (v / 1000) % 10;
-			hb[3] = '0' + (v / 100) % 10;
-			hb[4] = '0' + (v / 10) % 10;
-			hb[5] = '0' + v % 10;
-			hb[6] = 0;
-			tInfo_write(hb);
-		}
-
-		/* Use blocking receive to catch ANY byte from module.
-		 * 500ms timeout — will show CONNECT text, RING, or data bytes. */
-		{
-			uint8_t rxByte = 0;
-			if(HAL_UART_Receive(&UartHandle, &rxByte, 1, 500) == HAL_OK)
-			{
-				/* Collect first bytes for diagnostic display */
-				if(diagLen < sizeof(diagBuf))
-					diagBuf[diagLen++] = rxByte;
-
-				/* Show each received byte */
-				if(rxByteCount < 6)
-				{
-					char rxMsg[16];
-					rxMsg[0] = 'R';
-					rxMsg[1] = 'x';
-					rxMsg[2] = ':';
-					uint8_t hi = rxByte >> 4;
-					uint8_t lo = rxByte & 0x0F;
-					rxMsg[3] = hi < 10 ? '0' + hi : 'A' + hi - 10;
-					rxMsg[4] = lo < 10 ? '0' + lo : 'A' + lo - 10;
-					rxMsg[5] = '=';
-					rxMsg[6] = (rxByte >= 0x20 && rxByte < 0x7F) ? rxByte : '.';
-					rxMsg[7] = 0;
-					tInfo_write(rxMsg);
-					rxByteCount++;
-				}
-
-				if((rxByte == BYTE_DOWNLOAD_MODE) || (rxByte == BYTE_SERVICE_MODE))
-				{
-					receiveStartByteUart = rxByte;
+				UartReady = RESET;
+				if((receiveStartByteUart == BYTE_DOWNLOAD_MODE) || (receiveStartByteUart == BYTE_SERVICE_MODE))
 					answer = openComm(receiveStartByteUart);
-					return answer;
-				}
-			}
+				StartListeningToUART = 1;
+				return answer;
 		}
     }
     return 0;
@@ -2198,13 +2133,6 @@ uint8_t tComm_HandleBlueModConfig()
 				ConfigRetryCnt = 0;
 				if (!isNewDisplay()) {
 					RestartModule = 1;
-					if(BmTmpConfig == BM_CONFIG_DONE)
-					{
-						if(UartHandle.Init.BaudRate == 460800)
-							tInfo_write("Cfg 460k OK");
-						else
-							tInfo_write("Cfg 115k OK");
-					}
 				}
 				break;
 
@@ -2309,32 +2237,9 @@ uint8_t tComm_HandleBlueModConfig()
 				case BM_INIT_RESTART:		BmTmpConfig++; /* Stollmann: AT+RESET not confirmed to work; AT&W already saved, skip */
 										break;
 				case BM_INIT_DONE:			{
-											/* Query S0 register (auto-answer) for diagnostics */
-											HAL_Delay(200);
-											{
-												char s0cmd[] = "ATS0?\r";
-												char s0resp[20];
-												memset(s0resp, 0, sizeof(s0resp));
-												HAL_UART_Transmit(&UartHandle, (uint8_t*)s0cmd, strlen(s0cmd), 500);
-												HAL_UART_Receive(&UartHandle, (uint8_t*)s0resp, 16, 500);
-												/* Show first chars of response.
-												 * Expected: "xxx\r\nOK\r\n" where xxx = S0 value */
-												char s0msg[14] = "S0=";
-												uint8_t mi = 3;
-												for(int i = 0; i < 12 && mi < 12; i++) {
-													uint8_t c = (uint8_t)s0resp[i];
-													if(c >= 0x20 && c < 0x7F)
-														s0msg[mi++] = c;
-													else if(c == '\r' || c == '\n')
-														s0msg[mi++] = '.';
-												}
-												s0msg[mi] = 0;
-												tInfo_write(s0msg);
-											}
-
 											/* Power-cycle the module so BT stack reinitializes
 											 * with the saved settings (AT&F1+ATE0+BNAME+ATS30=0+AT&W).
-											 * Without restart, the BT stack may not properly
+											 * Without restart, the module may not properly
 											 * accept incoming SPP connections. */
 											MX_Bluetooth_PowerOff();
 											HAL_Delay(100);
@@ -2342,58 +2247,16 @@ uint8_t tComm_HandleBlueModConfig()
 											HAL_Delay(3000);
 											tComm_AssertRTS();
 
-											/* Collect any boot-up text for diagnostics */
+											/* Drain any boot-up text from the module */
 											{
-												char bootBuf[32];
-												memset(bootBuf, 0, sizeof(bootBuf));
-												HAL_UART_Receive(&UartHandle, (uint8_t*)bootBuf, 30, 500);
-												/* Show first printable chars of boot text */
-												char bm[14] = "Boot:";
-												uint8_t bi = 5;
-												for(int i = 0; i < 30 && bi < 12; i++) {
-													uint8_t c = (uint8_t)bootBuf[i];
-													if(c >= 0x20 && c < 0x7F)
-														bm[bi++] = c;
-													else if(c == '\r' || c == '\n')
-														bm[bi++] = '.';
-													else if(c != 0)
-														bm[bi++] = '?';
-												}
-												bm[bi] = 0;
-												tInfo_write(bm);
+												uint8_t dummy;
+												while(HAL_UART_Receive(&UartHandle, &dummy, 1, 50) == HAL_OK) {}
 											}
 
-											/* Verify module alive after reboot */
-											{
-												char atcmd[] = "AT\r";
-												HAL_UART_Transmit(&UartHandle, (uint8_t*)atcmd, 3, 500);
-												if(tComm_CheckAnswerOK() == HAL_OK)
-													tInfo_write("AT OK");
-												else
-													tInfo_write("AT FAIL");
-											}
-
-											/* Query S30 (CONNECT text suppression) */
-											{
-												char s30cmd[] = "ATS30?\r";
-												char s30resp[20];
-												memset(s30resp, 0, sizeof(s30resp));
-												HAL_UART_Transmit(&UartHandle, (uint8_t*)s30cmd, strlen(s30cmd), 500);
-												HAL_UART_Receive(&UartHandle, (uint8_t*)s30resp, 16, 500);
-												char s30msg[14] = "S30=";
-												uint8_t si = 4;
-												for(int i = 0; i < 12 && si < 12; i++) {
-													uint8_t c = (uint8_t)s30resp[i];
-													if(c >= 0x20 && c < 0x7F)
-														s30msg[si++] = c;
-													else if(c == '\r' || c == '\n')
-														s30msg[si++] = '.';
-												}
-												s30msg[si] = 0;
-												tInfo_write(s30msg);
-											}
-
-											BmTmpConfig = BM_CONFIG_DONE;
+											/* Run normal CONFIG sequence (ATE0, ATS12, BSTPOLL,
+											 * baud rate, ATS30) so the module is ready for
+											 * the firmware to talk to it. */
+											BmTmpConfig = BM_CONFIG_ECHO;
 											return result;
 										}
 				default:
@@ -2454,13 +2317,6 @@ uint8_t tComm_HandleBlueModConfig()
 			ConfigRetryCnt++;
 			if(ConfigRetryCnt > 3)		/* Configuration failed => switch off module */
 			{
-				/* Show which CONFIG step failed */
-				if(BmTmpConfig == BM_CONFIG_ECHO)
-					tInfo_write("Fail@ECHO");
-				else if(BmTmpConfig == BM_CONFIG_BAUD)
-					tInfo_write("Fail@BAUD");
-				else
-					tInfo_write("Fail@CFG");
 				MX_Bluetooth_PowerOff();
 
 				if (!isNewDisplay()) {
@@ -2489,7 +2345,6 @@ uint8_t tComm_HandleBlueModConfig()
 						HAL_Delay(500);
 						UartHandle.Init.BaudRate = 115200;
 						HAL_UART_Init(&UartHandle);
-						tInfo_write("Fallback 115k");
 						BmTmpConfig = BM_CONFIG_DONE;
 					}
 				}

--- a/BootLoader/Src/tComm_mini.c
+++ b/BootLoader/Src/tComm_mini.c
@@ -420,22 +420,21 @@ uint8_t tComm_control(void)
     else
     {
     /*##-2- Put UART peripheral in reception process ###########################*/
+    /* Use polling receive instead of interrupt-based to avoid overrun errors.
+     * With IT-based receive, the ISR captures byte 0 (e.g. 0xAA) but no IT
+     * receive is active while the main loop processes it and enters openComm().
+     * At 460800 baud, subsequent bytes arrive ~22us apart and are lost to ORE
+     * before openComm's blocking receive starts.
+     * Polling avoids this: we read byte 0 from DR and immediately enter
+     * openComm(), which starts HAL_UART_Receive for the remaining bytes
+     * before the next byte finishes clocking in. */
 
-		if((UartReady == RESET) && StartListeningToUART)
+		receiveStartByteUart = 0;
+		if(HAL_UART_Receive(&UartHandle, &receiveStartByteUart, 1, 100) == HAL_OK)
 		{
-				StartListeningToUART = 0;
-				receiveStartByteUart = 0;
-				if(HAL_UART_Receive_IT(&UartHandle, &receiveStartByteUart, 1) != HAL_OK)
-						tComm_Error_Handler();
-		}
-		/* Reset transmission flag */
-		if(UartReady == SET)
-		{
-				UartReady = RESET;
-				if((receiveStartByteUart == BYTE_DOWNLOAD_MODE) || (receiveStartByteUart == BYTE_SERVICE_MODE))
-					answer = openComm(receiveStartByteUart);
-				StartListeningToUART = 1;
-				return answer;
+			if((receiveStartByteUart == BYTE_DOWNLOAD_MODE) || (receiveStartByteUart == BYTE_SERVICE_MODE))
+				answer = openComm(receiveStartByteUart);
+			return answer;
 		}
     }
     return 0;

--- a/BootLoader/Src/tComm_mini.c
+++ b/BootLoader/Src/tComm_mini.c
@@ -366,9 +366,12 @@ void tComm_RecoverBluetoothModule(void)
         tComm_InitUartNoFC(working_baud);
         HAL_Delay(100);
 
-        /* 1. Disable flow control on the module (Stollmann: AT\Q0) */
-        tComm_ProbeModule("AT\\Q0\r", RxBuffer, 500);
-        HAL_Delay(100);
+        /* 1. Factory reset the module (Stollmann: AT&F1).
+         *    This restores factory defaults: 115200, flow control ON, echo ON.
+         *    The firmware/bootloader UART expects RTS/CTS flow control,
+         *    so we must NOT disable it. */
+        tComm_ProbeModule("AT&F1\r", RxBuffer, 1000);
+        HAL_Delay(500);
 
         /* 2. Set baud rate to 115200 if needed (Stollmann: AT%B8) */
         if (working_baud != 115200)
@@ -417,21 +420,87 @@ uint8_t tComm_control(void)
     else
     {
     /*##-2- Put UART peripheral in reception process ###########################*/
+		static uint8_t listeningMsgShown = 0;
+		static uint8_t rxByteCount = 0;
+		static uint8_t diagBuf[8];
+		static uint8_t diagLen = 0;
+		static uint8_t lastCTS = 0xFF;
+		static uint16_t pollCount = 0;
 
-		if((UartReady == RESET) && StartListeningToUART)
+		if(!listeningMsgShown)
 		{
-				StartListeningToUART = 0;
-				if(HAL_UART_Receive_IT(&UartHandle, &receiveStartByteUart, 1) != HAL_OK)
-						tComm_Error_Handler();
+			if(UartHandle.Init.BaudRate == 460800)
+				tInfo_write("Listen 460k");
+			else
+				tInfo_write("Listen 115k");
+			listeningMsgShown = 1;
 		}
-		/* Reset transmission flag */
-		if(UartReady == SET)
+
+		/* Monitor CTS (PA11 = module RTS#) for state changes.
+		 * If it transitions, the module is signaling something. */
 		{
-				UartReady = RESET;
-				if((receiveStartByteUart == BYTE_DOWNLOAD_MODE) || (receiveStartByteUart == BYTE_SERVICE_MODE))
+			uint8_t cts = HAL_GPIO_ReadPin(GPIOA, GPIO_PIN_11);
+			if(cts != lastCTS)
+			{
+				lastCTS = cts;
+				if(cts == GPIO_PIN_SET)
+					tInfo_write("CTS->1");
+				else
+					tInfo_write("CTS->0");
+			}
+		}
+
+		/* Show poll count every 20 iterations (~10s) as heartbeat */
+		pollCount++;
+		if(pollCount % 20 == 0)
+		{
+			char hb[12];
+			hb[0] = '#';
+			uint16_t v = pollCount;
+			hb[1] = '0' + (v / 10000) % 10;
+			hb[2] = '0' + (v / 1000) % 10;
+			hb[3] = '0' + (v / 100) % 10;
+			hb[4] = '0' + (v / 10) % 10;
+			hb[5] = '0' + v % 10;
+			hb[6] = 0;
+			tInfo_write(hb);
+		}
+
+		/* Use blocking receive to catch ANY byte from module.
+		 * 500ms timeout — will show CONNECT text, RING, or data bytes. */
+		{
+			uint8_t rxByte = 0;
+			if(HAL_UART_Receive(&UartHandle, &rxByte, 1, 500) == HAL_OK)
+			{
+				/* Collect first bytes for diagnostic display */
+				if(diagLen < sizeof(diagBuf))
+					diagBuf[diagLen++] = rxByte;
+
+				/* Show each received byte */
+				if(rxByteCount < 6)
+				{
+					char rxMsg[16];
+					rxMsg[0] = 'R';
+					rxMsg[1] = 'x';
+					rxMsg[2] = ':';
+					uint8_t hi = rxByte >> 4;
+					uint8_t lo = rxByte & 0x0F;
+					rxMsg[3] = hi < 10 ? '0' + hi : 'A' + hi - 10;
+					rxMsg[4] = lo < 10 ? '0' + lo : 'A' + lo - 10;
+					rxMsg[5] = '=';
+					rxMsg[6] = (rxByte >= 0x20 && rxByte < 0x7F) ? rxByte : '.';
+					rxMsg[7] = 0;
+					tInfo_write(rxMsg);
+					rxByteCount++;
+				}
+
+				if((rxByte == BYTE_DOWNLOAD_MODE) || (rxByte == BYTE_SERVICE_MODE))
+				{
+					receiveStartByteUart = rxByte;
 					answer = openComm(receiveStartByteUart);
-				StartListeningToUART = 1;
-				return answer;
+					return answer;
+				}
+			}
 		}
     }
     return 0;
@@ -1970,16 +2039,18 @@ void tComm_StartBlueModBaseInit()
 		BmTmpConfig = BM_INIT_POWEROFF;
 	} else {
 		/* Old Stollmann module (OSTC4):
-		 * For init/recovery, do a power cycle then use the same
-		 * working config sequence as tComm_StartBlueModConfig().
+		 * Power cycle, init UART, then start the full BM_INIT_*
+		 * sequence (factory reset, set name, save, restart).
 		 */
 		MX_Bluetooth_PowerOff();
 		HAL_Delay(100);
 		MX_Bluetooth_PowerOn();
 		HAL_Delay(1000);  /* Give module time to boot */
 
-		/* Now use the same approach as the working tComm_StartBlueModConfig() */
+		/* Init UART hardware + flush RX buffer */
 		tComm_StartBlueModConfig();
+		/* Override: run full INIT sequence (includes name setting) */
+		BmTmpConfig = BM_INIT_TRIGGER_ON;
 	}
 }
 
@@ -2052,28 +2123,12 @@ void tComm_StartBlueModConfig()
 	HAL_UART_Init(&UartHandle);
 
     if (!isNewDisplay()) {
-        /* Old Stollmann module (OSTC4) */
-        uint8_t answer = HAL_OK;
-        uint8_t RxBuffer[UART_CMD_BUF_SIZE];
-        uint8_t index = 0;
-        uint8_t dummy = 0;
-
+        /* Old Stollmann module (OSTC4):
+         * Assert RTS (PA12 LOW) manually since the bootloader doesn't
+         * configure PA11/PA12 as AF (USART1_CTS_PIN not defined).
+         * The module's CTS# needs to see LOW to transmit to us. */
+        tComm_AssertRTS();
         BmTmpConfig = BM_CONFIG_ECHO;
-        do	/* flush RX buffer */
-        {
-            if(index < UART_CMD_BUF_SIZE)
-            {
-                answer = HAL_UART_Receive(&UartHandle, (uint8_t*)&RxBuffer[index], 1, 10);
-                if(answer == HAL_OK)
-                {
-                    index++;
-                }
-            }
-            else
-            {
-                answer = HAL_UART_Receive(&UartHandle, (uint8_t*)&dummy, 1, 10);
-            }
-        }while(answer == HAL_OK);
     } else {
 		/* New u-blox module (OSTC5) */
 		BmTmpConfig = BM_CONFIG_DONE;
@@ -2143,6 +2198,13 @@ uint8_t tComm_HandleBlueModConfig()
 				ConfigRetryCnt = 0;
 				if (!isNewDisplay()) {
 					RestartModule = 1;
+					if(BmTmpConfig == BM_CONFIG_DONE)
+					{
+						if(UartHandle.Init.BaudRate == 460800)
+							tInfo_write("Cfg 460k OK");
+						else
+							tInfo_write("Cfg 115k OK");
+					}
 				}
 				break;
 
@@ -2223,9 +2285,9 @@ uint8_t tComm_HandleBlueModConfig()
 					break;
 				case BM_INIT_FACTORY:		sprintf(TxBuffer,"AT&F1\r");      /* Stollmann: Factory reset */
 										break;
-                case BM_INIT_MODE:			TxBuffer[0] = 0; /* Stollmann: No mode command needed, skip this step */
+                case BM_INIT_MODE:			BmTmpConfig++; /* Stollmann: No mode command needed, skip */
                                         break;
-                case BM_INIT_BLE:			TxBuffer[0] = 0; /* Stollmann: Skip, will use UBTLN after BNAME */
+                case BM_INIT_BLE:			BmTmpConfig++; /* Stollmann: No BLE mode command needed, skip */
                                         break;
                 case BM_INIT_NAME:			sprintf(TxBuffer,"AT+BNAME=OSTC4-12345\r"); /* Stollmann: Classic Bluetooth name */
                                         if(hardwareDataGetPointer()->primarySerial != 0xFFFF)
@@ -2234,24 +2296,106 @@ uint8_t tComm_HandleBlueModConfig()
                                             hardware_programmPrimaryBluetoothNameSet();
                                         }
 										break;
-                case BM_INIT_SSP_IDO_OFF:	sprintf(TxBuffer,"AT+UBTLN=OSTC4-12345\r"); /* Stollmann: BLE Device Name (after classic name) */
-                                        if(hardwareDataGetPointer()->primarySerial != 0xFFFF)
-                                        {
-                                            gfx_number_to_string(5,1,&TxBuffer[15],hardwareDataGetPointer()->primarySerial);
-                                        }
+                case BM_INIT_SSP_IDO_OFF:	BmTmpConfig++; /* Stollmann: AT+UBTLN is u-blox only, skip */
                                         break;
-                case BM_INIT_SSP_IDO_ON:	TxBuffer[0] = 0; /* Stollmann: No SSP command needed, skip */
+                case BM_INIT_SSP_IDO_ON:	sprintf(TxBuffer,"ATS30=0\r"); /* Stollmann: Show CONNECT/RING text (saved by AT&W) */
                                         break;
-				case BM_INIT_SSP_ID1_OFF:	TxBuffer[0] = 0; /* Stollmann: No SSP command needed, skip */
+				case BM_INIT_SSP_ID1_OFF:	BmTmpConfig++; /* Stollmann: No SSP command needed, skip */
 										break;
-				case BM_INIT_SSP_ID1_ON:	TxBuffer[0] = 0; /* Stollmann: No SSP command needed, skip */
+				case BM_INIT_SSP_ID1_ON:	BmTmpConfig++; /* Stollmann: No SSP command needed, skip */
 										break;
 				case BM_INIT_STORE:			sprintf(TxBuffer,"AT&W\r");	      /* Stollmann: Write settings to EEPROM */
 										break;
-				case BM_INIT_RESTART:		sprintf(TxBuffer,"AT+RESET\r");	  /* Stollmann: Reboot module */
+				case BM_INIT_RESTART:		BmTmpConfig++; /* Stollmann: AT+RESET not confirmed to work; AT&W already saved, skip */
 										break;
-				case BM_INIT_DONE:			BmTmpConfig = BM_CONFIG_ECHO;
-										break;
+				case BM_INIT_DONE:			{
+											/* Query S0 register (auto-answer) for diagnostics */
+											HAL_Delay(200);
+											{
+												char s0cmd[] = "ATS0?\r";
+												char s0resp[20];
+												memset(s0resp, 0, sizeof(s0resp));
+												HAL_UART_Transmit(&UartHandle, (uint8_t*)s0cmd, strlen(s0cmd), 500);
+												HAL_UART_Receive(&UartHandle, (uint8_t*)s0resp, 16, 500);
+												/* Show first chars of response.
+												 * Expected: "xxx\r\nOK\r\n" where xxx = S0 value */
+												char s0msg[14] = "S0=";
+												uint8_t mi = 3;
+												for(int i = 0; i < 12 && mi < 12; i++) {
+													uint8_t c = (uint8_t)s0resp[i];
+													if(c >= 0x20 && c < 0x7F)
+														s0msg[mi++] = c;
+													else if(c == '\r' || c == '\n')
+														s0msg[mi++] = '.';
+												}
+												s0msg[mi] = 0;
+												tInfo_write(s0msg);
+											}
+
+											/* Power-cycle the module so BT stack reinitializes
+											 * with the saved settings (AT&F1+ATE0+BNAME+ATS30=0+AT&W).
+											 * Without restart, the BT stack may not properly
+											 * accept incoming SPP connections. */
+											MX_Bluetooth_PowerOff();
+											HAL_Delay(100);
+											MX_Bluetooth_PowerOn();
+											HAL_Delay(3000);
+											tComm_AssertRTS();
+
+											/* Collect any boot-up text for diagnostics */
+											{
+												char bootBuf[32];
+												memset(bootBuf, 0, sizeof(bootBuf));
+												HAL_UART_Receive(&UartHandle, (uint8_t*)bootBuf, 30, 500);
+												/* Show first printable chars of boot text */
+												char bm[14] = "Boot:";
+												uint8_t bi = 5;
+												for(int i = 0; i < 30 && bi < 12; i++) {
+													uint8_t c = (uint8_t)bootBuf[i];
+													if(c >= 0x20 && c < 0x7F)
+														bm[bi++] = c;
+													else if(c == '\r' || c == '\n')
+														bm[bi++] = '.';
+													else if(c != 0)
+														bm[bi++] = '?';
+												}
+												bm[bi] = 0;
+												tInfo_write(bm);
+											}
+
+											/* Verify module alive after reboot */
+											{
+												char atcmd[] = "AT\r";
+												HAL_UART_Transmit(&UartHandle, (uint8_t*)atcmd, 3, 500);
+												if(tComm_CheckAnswerOK() == HAL_OK)
+													tInfo_write("AT OK");
+												else
+													tInfo_write("AT FAIL");
+											}
+
+											/* Query S30 (CONNECT text suppression) */
+											{
+												char s30cmd[] = "ATS30?\r";
+												char s30resp[20];
+												memset(s30resp, 0, sizeof(s30resp));
+												HAL_UART_Transmit(&UartHandle, (uint8_t*)s30cmd, strlen(s30cmd), 500);
+												HAL_UART_Receive(&UartHandle, (uint8_t*)s30resp, 16, 500);
+												char s30msg[14] = "S30=";
+												uint8_t si = 4;
+												for(int i = 0; i < 12 && si < 12; i++) {
+													uint8_t c = (uint8_t)s30resp[i];
+													if(c >= 0x20 && c < 0x7F)
+														s30msg[si++] = c;
+													else if(c == '\r' || c == '\n')
+														s30msg[si++] = '.';
+												}
+												s30msg[si] = 0;
+												tInfo_write(s30msg);
+											}
+
+											BmTmpConfig = BM_CONFIG_DONE;
+											return result;
+										}
 				default:
 					break;
 			}
@@ -2291,19 +2435,9 @@ uint8_t tComm_HandleBlueModConfig()
 				if(result == HAL_OK)
 				{
 					ConfigRetryCnt = 0;
-					BmTmpConfig++;
-					if(BmTmpConfig == BM_CONFIG_RETRY)
+					if((BmTmpConfig != BM_CONFIG_DONE))
 					{
-						BmTmpConfig = BM_CONFIG_DONE;
-					}
-				}
-				if (!isNewDisplay()) {
-					/* Stollmann module: skip to done after echo */
-					if(BmTmpConfig == BM_CONFIG_ECHO)
-					{
-						BmTmpConfig = BM_CONFIG_DONE;
-						ConfigRetryCnt = 0;
-						RestartModule = 1;
+						BmTmpConfig++;
 					}
 				}
 			}
@@ -2320,12 +2454,17 @@ uint8_t tComm_HandleBlueModConfig()
 			ConfigRetryCnt++;
 			if(ConfigRetryCnt > 3)		/* Configuration failed => switch off module */
 			{
+				/* Show which CONFIG step failed */
+				if(BmTmpConfig == BM_CONFIG_ECHO)
+					tInfo_write("Fail@ECHO");
+				else if(BmTmpConfig == BM_CONFIG_BAUD)
+					tInfo_write("Fail@BAUD");
+				else
+					tInfo_write("Fail@CFG");
 				MX_Bluetooth_PowerOff();
-				tInfo_write("Failed");
-				BmTmpConfig = BM_CONFIG_OFF;
 
 				if (!isNewDisplay()) {
-					/* Stollmann module: retry logic */
+					/* Stollmann module: retry logic (matching firmware structure) */
 					if(RestartModule)
 					{
 						RestartModule = 0;      /* only one try */
@@ -2340,10 +2479,18 @@ uint8_t tComm_HandleBlueModConfig()
 						}
 						BmTmpConfig = BM_CONFIG_RETRY;
 					}
-					else						/* even restarting module failed => switch bluetooth off */
+					else						/* even restarting module failed => try listening anyway */
 					{
 						ConfigRetryCnt = 0;
-						BmTmpConfig = BM_CONFIG_OFF;
+						/* Power the module back on and try to listen.
+						 * The module may still be at 115200 (saved default), so
+						 * reinit UART to 115200 as a fallback. */
+						MX_Bluetooth_PowerOn();
+						HAL_Delay(500);
+						UartHandle.Init.BaudRate = 115200;
+						HAL_UART_Init(&UartHandle);
+						tInfo_write("Fallback 115k");
+						BmTmpConfig = BM_CONFIG_DONE;
 					}
 				}
 			}

--- a/BootLoader/Src/tComm_mini.c
+++ b/BootLoader/Src/tComm_mini.c
@@ -247,7 +247,7 @@ void tComm_RecoverBluetoothModule(void)
     uint8_t rxLen;
     uint8_t recovery_success = 0;
     uint32_t working_baud = 0;
-    uint8_t saved_flow_control;
+    uint32_t saved_flow_control;
 
     bt_debug.state = 1;  /* testing */
     bt_debug.power_cycle_count = 0;
@@ -405,7 +405,11 @@ void tComm_RecoverBluetoothModule(void)
     /* Restore UART to normal operating config */
     UartHandle.Init.BaudRate  = 115200;
     UartHandle.Init.HwFlowCtl = saved_flow_control;
-    HAL_UART_Init(&UartHandle);
+    if (HAL_UART_Init(&UartHandle) != HAL_OK)
+    {
+        /* Log UART restore failure for debugging via ST-Link */
+        bt_debug.state = 5;  /* restore_failed */
+    }
 }
 
 uint8_t tComm_control(void)
@@ -524,12 +528,23 @@ void tComm_exit(void)
         /* Trigger full Bluetooth module re-initialization to set BLE name */
         BmTmpConfig = BM_INIT_TRIGGER_ON;
         
-        /* Wait for state machine to complete all initialization states */
-        uint32_t timeout = HAL_GetTick() + 30000;  /* 30 second timeout */
-        while((BmTmpConfig != BM_CONFIG_DONE) && (HAL_GetTick() < timeout))
+        /* Wait for state machine to complete all initialization states.
+         * Note: setForcedBluetoothName is cleared above, so even if tComm_control()
+         * triggers set_returnFromComm(), tComm_exit() won't re-enter this block.
+         * This deferred-exit behavior is intentional and safe. */
+          uint32_t startTick = HAL_GetTick();
+          while((BmTmpConfig != BM_CONFIG_DONE)
+              && (time_elapsed_ms(startTick, HAL_GetTick()) < 30000))
         {
             tComm_control();  /* Drive the Bluetooth initialization state machine */
             HAL_Delay(10);
+        }
+        
+        /* Check if initialization completed successfully or timed out */
+        if (BmTmpConfig != BM_CONFIG_DONE)
+        {
+            /* Initialization timed out - module may not be properly configured */
+            bt_debug.state = 0xFF;  /* Mark as failed */
         }
     }
 
@@ -588,14 +603,11 @@ uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence)
     // limit is 19 chars, with 7 chars shown in BLE advertising mode
     //________________________123456789012345678901
 
-    tComm_GetBTCmdStr(BT_CMD_NAME, aTxBufferName);
-
     char answerOkay[6] = "\r\nOK\r\n";
 
+    tComm_GetBTCmdStr(BT_CMD_NAME, aTxBufferName);
     gfx_number_to_string(5,1,&aTxBufferName[15],serial);
 
-    // For Stollmann module: prepare BLE name command using proper enum
-    // This ensures the correct AT command is sent for each module type
     tComm_GetBTCmdStr(BT_CMD_BLE_NAME, aTxBufferBLEName);
     gfx_number_to_string(5,1,&aTxBufferBLEName[15],serial);
 
@@ -603,7 +615,6 @@ uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence)
     char aTxBufferWrite[50] = "AT&W\r";
 
 //	char aTxBufferReset[50] = "AT+RESET\r";
-
 
     HAL_Delay(1010);
     if(withEscapeSequence)
@@ -615,39 +626,39 @@ uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence)
         HAL_Delay(1010);
 
         for(int i=0;i<3;i++)
-        if(aRxBuffer[i] != '+')
-            answer = HAL_ERROR;
+            if(aRxBuffer[i] != '+')
+                answer = HAL_ERROR;
     }
 
-    // Send classic BT name command (AT+BNAME=OSTC4-xxxxx)
+    // Send classic BT name command
     aRxBuffer[0] = 0;
     if(HAL_UART_Transmit(&UartHandle, (uint8_t*)aTxBufferName, 21, 2000)!= HAL_OK)
         answer = HAL_ERROR;
     HAL_UART_Receive(&UartHandle, (uint8_t*)aRxBuffer, 21+6, 2000);
 
     for(int i=0;i<21;i++)
-    if(aRxBuffer[i] != aTxBufferName[i])
-        answer = HAL_ERROR;
+        if(aRxBuffer[i] != aTxBufferName[i])
+            answer = HAL_ERROR;
 
     for(int i=0;i<6;i++)
-    if(aRxBuffer[21+i] != answerOkay[i])
-        answer = HAL_ERROR;
+        if(aRxBuffer[21+i] != answerOkay[i])
+            answer = HAL_ERROR;
 
     HAL_Delay(200);
 
-    // Send BLE name command (AT+UBTLN=OSTC4-xxxxx)
+    // Send BLE name command
     aRxBuffer[0] = 0;
     if(HAL_UART_Transmit(&UartHandle, (uint8_t*)aTxBufferBLEName, 21, 2000)!= HAL_OK)
         answer = HAL_ERROR;
     HAL_UART_Receive(&UartHandle, (uint8_t*)aRxBuffer, 21+6, 2000);
 
     for(int i=0;i<21;i++)
-    if(aRxBuffer[i] != aTxBufferBLEName[i])
-        answer = HAL_ERROR;
+        if(aRxBuffer[i] != aTxBufferBLEName[i])
+            answer = HAL_ERROR;
 
     for(int i=0;i<6;i++)
-    if(aRxBuffer[21+i] != answerOkay[i])
-        answer = HAL_ERROR;
+        if(aRxBuffer[21+i] != answerOkay[i])
+            answer = HAL_ERROR;
 
     HAL_Delay(200);
 
@@ -657,14 +668,13 @@ uint8_t HW_Set_Bluetooth_Name(uint16_t serial, uint8_t withEscapeSequence)
     HAL_UART_Receive(&UartHandle, (uint8_t*)aRxBuffer, 5+6, 2000);
 
     for(int i=0;i<5;i++)
-    if(aRxBuffer[i] != aTxBufferWrite[i])
-        answer = HAL_ERROR;
+        if(aRxBuffer[i] != aTxBufferWrite[i])
+            answer = HAL_ERROR;
 
     for(int i=0;i<6;i++)
-    if(aRxBuffer[5+i] != answerOkay[i])
-        answer = HAL_ERROR;
+        if(aRxBuffer[5+i] != answerOkay[i])
+            answer = HAL_ERROR;
 
-    answer = HAL_OK;
     return answer;
 }
 
@@ -2025,9 +2035,9 @@ uint8_t tComm_GetBTCmdStr(BTCmd cmdId, char* pCmdStr)
 			case BT_CMD_NAME:			strcpy(pCmdStr,"AT+BNAME=OSTC4-12345\r");
 										ret = 1;
 				break;
-			case BT_CMD_BLE_NAME:		strcpy(pCmdStr,"AT+UBTLN=OSTC4-12345\r");
-									ret = 1;
-				break;
+            case BT_CMD_BLE_NAME:		strcpy(pCmdStr,"AT+BNAME=OSTC4-12345\r");
+                                    ret = 1;
+                break;
 			case BT_CMD_EXIT_CMD:		strcpy(pCmdStr,"ATO\r");
 										ret = 1;
 				break;
@@ -2050,9 +2060,13 @@ uint8_t tComm_GetBTCmdStr(BTCmd cmdId, char* pCmdStr)
 			case BT_CMD_NAME:			strcpy(pCmdStr,"AT+UBTLN=OSTC5-12345\r");
 										ret = 1;
 				break;
-		case BT_CMD_BLE_NAME:		strcpy(pCmdStr,"AT+UBTLN=OSTC5-12345\r");
-									ret = 1;
-			break;
+			case BT_CMD_BLE_NAME:		strcpy(pCmdStr,"AT+UBTLN=OSTC5-12345\r");
+										ret = 1;
+				break;
+			case BT_CMD_EXIT_CMD:
+				/* No explicit exit from command mode required for u-blox (OSTC5).
+				 * Keep ret == 0 so callers know no command string was generated. */
+				break;
 			default:
 				break;
 		}
@@ -2231,7 +2245,7 @@ uint8_t tComm_HandleBlueModConfig()
                                             hardware_programmPrimaryBluetoothNameSet();
                                         }
 										break;
-                case BM_INIT_SSP_IDO_OFF:	BmTmpConfig++; /* Stollmann: AT+UBTLN is u-blox only, skip */
+                case BM_INIT_SSP_IDO_OFF:	BmTmpConfig++; /* Stollmann: No SPP ID0 disable command needed, skip */
                                         break;
                 case BM_INIT_SSP_IDO_ON:	sprintf(TxBuffer,"ATS30=0\r"); /* Stollmann: Show CONNECT/RING text (saved by AT&W) */
                                         break;

--- a/BootLoader/Src/tComm_mini.c
+++ b/BootLoader/Src/tComm_mini.c
@@ -271,8 +271,17 @@ void tComm_exit(void)
         MX_Bluetooth_PowerOff();
         HAL_Delay(1000);
         MX_Bluetooth_PowerOn();
-        tComm_Set_Bluetooth_Name(1);
-        tComm_StartBlueModConfig();
+        HAL_Delay(1000);
+        /* Trigger full Bluetooth module re-initialization to set BLE name */
+        BmTmpConfig = BM_INIT_TRIGGER_ON;
+        
+        /* Wait for state machine to complete all initialization states */
+        uint32_t timeout = HAL_GetTick() + 30000;  /* 30 second timeout */
+        while((BmTmpConfig != BM_CONFIG_DONE) && (HAL_GetTick() < timeout))
+        {
+            tComm_control();  /* Drive the Bluetooth initialization state machine */
+            HAL_Delay(10);
+        }
     }
 
     updateSettingsAndMenuOnExit = 0;

--- a/Discovery/Inc/tComm.h
+++ b/Discovery/Inc/tComm.h
@@ -77,6 +77,7 @@ typedef enum
 	BT_CMD_BAUDRATE_460,
 	BT_CMD_SILENCE,
 	BT_CMD_NAME,
+    BT_CMD_BLE_NAME,
 	BT_CMD_EXIT_CMD
 } BTCmd;
 /* Exported functions --------------------------------------------------------*/

--- a/Discovery/Inc/tComm.h
+++ b/Discovery/Inc/tComm.h
@@ -91,5 +91,6 @@ uint8_t tComm_Set_Bluetooth_Name(uint8_t force);
 void tComm_StartBlueModBaseInit(void);
 void tComm_StartBlueModConfig(void);
 void tComm_RequestBluetoothStrength(void);
+void tComm_RecoverBluetoothModule(void);
 
 #endif /* TCOMM_H */

--- a/Documentations/set_manufacturing_data.py
+++ b/Documentations/set_manufacturing_data.py
@@ -125,23 +125,26 @@ def read_hardware_data(ser):
         raise Exception(f"Expected 64 bytes, got {len(data)}")
     
     # Parse primary manufacturing data (first 52 bytes)
+    # Structure: serial(2) + licence(1) + revision(1) + date(3) + bt_name_set(1) + info(44)
     primary_serial = int.from_bytes(data[0:2], byteorder='little')
     primary_licence = data[2]
     primary_revision = data[3]
     primary_year = data[4]
     primary_month = data[5]
     primary_day = data[6]
-    primary_info = data[7:51].rstrip(b'\x00\xff').decode('ascii', errors='replace')
-    primary_checksum = data[51]
+    # data[7] = production_bluetooth_name_set (skip)
+    primary_info = data[8:52].rstrip(b'\x00\xff').decode('ascii', errors='replace')
     
     # Parse secondary manufacturing data (last 12 bytes)
+    # Structure: serial(2) + licence(1) + reason(1) + date(3) + bt_name_set(1) + info(4)
     secondary_serial = int.from_bytes(data[52:54], byteorder='little')
-    secondary_year = data[54]
-    secondary_month = data[55]
-    secondary_day = data[56]
-    secondary_reason = data[57]
-    secondary_info = data[58:62].rstrip(b'\x00\xff').decode('ascii', errors='replace')
-    secondary_checksum = data[62]
+    secondary_licence = data[54]
+    secondary_reason = data[55]
+    secondary_year = data[56]
+    secondary_month = data[57]
+    secondary_day = data[58]
+    # data[59] = secondary_bluetooth_name_set (skip)
+    secondary_info = data[60:64].rstrip(b'\x00\xff').decode('ascii', errors='replace')
     
     # Display primary data
     print("\n=== Primary Manufacturing Data ===")
@@ -154,17 +157,19 @@ def read_hardware_data(ser):
         print("Production Date: Not set")
     if primary_info:
         print(f"Info: {primary_info}")
-    print(f"Checksum: 0x{primary_checksum:02X}")
     
     # Display secondary data
     print("\n=== Secondary Manufacturing Data ===")
     if secondary_serial != 0xFFFF:
         print(f"Secondary Serial: {secondary_serial} (0x{secondary_serial:04X})")
-        print(f"Secondary Date: 20{secondary_year:02d}-{secondary_month:02d}-{secondary_day:02d}")
+        print(f"Secondary Licence: {secondary_licence}")
+        if secondary_year != 0xFF:
+            print(f"Secondary Date: 20{secondary_year:02d}-{secondary_month:02d}-{secondary_day:02d}")
+        else:
+            print("Secondary Date: Not set")
         print(f"Reason Code: {secondary_reason}")
         if secondary_info:
             print(f"Info: {secondary_info}")
-        print(f"Checksum: 0x{secondary_checksum:02X}")
     else:
         print("Secondary Serial: Not set")
     
@@ -468,11 +473,11 @@ def main():
             except Exception as e:
                 if needs_reinit_for_bt_name and "not echoed" in str(e):
                     print(f"Warning: {e}. Bluetooth disconnected after 0x80.")
-                    print("Please reconnect /dev/rfcomm0 now (e.g. via rfcomm), then press Enter.")
+                    print(f"Please reconnect {args.port} now (e.g. via rfcomm), then press Enter.")
                     try:
                         ser.close()
-                    except Exception:
-                        pass
+                    except Exception as close_err:
+                        print(f"Note: could not close port: {close_err}")
                     try:
                         input()
                     except EOFError:

--- a/Documentations/set_manufacturing_data.py
+++ b/Documentations/set_manufacturing_data.py
@@ -411,6 +411,7 @@ Examples:
 
 def main():
     args = parse_args()
+    needs_reinit_for_bt_name = False
     
     try:
         print(f"Opening {args.port}...")
@@ -439,8 +440,17 @@ def main():
             year, month, day = args.date
             # Pad info to 44 chars with spaces
             info = args.info.ljust(MAX_PROD_INFO_LEN)[:MAX_PROD_INFO_LEN]
-            write_production_data(ser, args.serial, args.licence, args.revision,
-                                year, month, day, info)
+            try:
+                write_production_data(ser, args.serial, args.licence, args.revision,
+                                    year, month, day, info)
+            except Exception as e:
+                # If the flash area is already programmed, the bootloader returns
+                # without sending a prompt. Allow continuing to BT name set.
+                if args.set_bluetooth_name and "Expected prompt" in str(e):
+                    print(f"Warning: {e}. Assuming production data already set; continuing to Bluetooth name.")
+                    needs_reinit_for_bt_name = True
+                else:
+                    raise
         
         # Write secondary serial if specified
         if args.secondary_serial is not None:
@@ -452,7 +462,29 @@ def main():
         
         # Set Bluetooth name if requested
         if args.set_bluetooth_name:
-            set_bluetooth_name(ser)
+            try:
+                # First try in the current session (often still in service mode)
+                set_bluetooth_name(ser)
+            except Exception as e:
+                if needs_reinit_for_bt_name and "not echoed" in str(e):
+                    print(f"Warning: {e}. Bluetooth disconnected after 0x80.")
+                    print("Please reconnect /dev/rfcomm0 now (e.g. via rfcomm), then press Enter.")
+                    try:
+                        ser.close()
+                    except Exception:
+                        pass
+                    try:
+                        input()
+                    except EOFError:
+                        raise Exception("Reconnection required but no input available.")
+                    ser = serial.Serial(args.port, 115200, timeout=args.timeout)
+                    time.sleep(0.5)
+                    ser.reset_input_buffer()
+                    ser.reset_output_buffer()
+                    send_service_mode_init(ser)
+                    set_bluetooth_name(ser)
+                else:
+                    raise
             print("\nThe device will now configure the Bluetooth module.")
             print("Wait for the bootloader to finish and reconnect.")
         

--- a/Documentations/set_manufacturing_data.py
+++ b/Documentations/set_manufacturing_data.py
@@ -108,11 +108,67 @@ def send_command(ser, cmd_byte):
     print(f"Command 0x{cmd_byte:02X} acknowledged (echo)")
 
 def wait_for_prompt(ser):
-    """Wait for the prompt byte (0x4D)"""
+    """Wait for the prompt byte (0x4D or 0x4C)"""
     prompt = ser.read(1)
-    if len(prompt) != 1 or prompt[0] != 0x4D:
-        raise Exception(f"Expected prompt 0x4D, got {prompt.hex() if prompt else 'nothing'}")
+    if len(prompt) != 1 or prompt[0] not in (0x4D, 0x4C):
+        raise Exception(f"Expected prompt 0x4D or 0x4C, got {prompt.hex() if prompt else 'nothing'}")
     print("Received prompt")
+
+def read_hardware_data(ser):
+    """Read hardware data (command 0x71) and display it"""
+    print("\nReading hardware data...")
+    send_command(ser, 0x71)
+    
+    # Read 64 bytes of hardware data
+    data = ser.read(64)
+    if len(data) != 64:
+        raise Exception(f"Expected 64 bytes, got {len(data)}")
+    
+    # Parse primary manufacturing data (first 52 bytes)
+    primary_serial = int.from_bytes(data[0:2], byteorder='little')
+    primary_licence = data[2]
+    primary_revision = data[3]
+    primary_year = data[4]
+    primary_month = data[5]
+    primary_day = data[6]
+    primary_info = data[7:51].rstrip(b'\x00\xff').decode('ascii', errors='replace')
+    primary_checksum = data[51]
+    
+    # Parse secondary manufacturing data (last 12 bytes)
+    secondary_serial = int.from_bytes(data[52:54], byteorder='little')
+    secondary_year = data[54]
+    secondary_month = data[55]
+    secondary_day = data[56]
+    secondary_reason = data[57]
+    secondary_info = data[58:62].rstrip(b'\x00\xff').decode('ascii', errors='replace')
+    secondary_checksum = data[62]
+    
+    # Display primary data
+    print("\n=== Primary Manufacturing Data ===")
+    print(f"Serial Number: {primary_serial} (0x{primary_serial:04X})")
+    print(f"Licence: {primary_licence}")
+    print(f"Revision: {primary_revision}")
+    if primary_year != 0xFF:
+        print(f"Production Date: 20{primary_year:02d}-{primary_month:02d}-{primary_day:02d}")
+    else:
+        print("Production Date: Not set")
+    if primary_info:
+        print(f"Info: {primary_info}")
+    print(f"Checksum: 0x{primary_checksum:02X}")
+    
+    # Display secondary data
+    print("\n=== Secondary Manufacturing Data ===")
+    if secondary_serial != 0xFFFF:
+        print(f"Secondary Serial: {secondary_serial} (0x{secondary_serial:04X})")
+        print(f"Secondary Date: 20{secondary_year:02d}-{secondary_month:02d}-{secondary_day:02d}")
+        print(f"Reason Code: {secondary_reason}")
+        if secondary_info:
+            print(f"Info: {secondary_info}")
+        print(f"Checksum: 0x{secondary_checksum:02X}")
+    else:
+        print("Secondary Serial: Not set")
+    
+    wait_for_prompt(ser)
 
 def write_production_data(ser, serial_num, licence, revision, year, month, day, info):
     """
@@ -323,6 +379,10 @@ Examples:
     bt.add_argument('--set-bluetooth-name', '-b', action='store_true',
                    help='Set Bluetooth name based on serial number')
     
+    # Read command
+    parser.add_argument('--read', action='store_true',
+                       help='Read current manufacturing data (command 0x71)')
+    
     # Other options
     parser.add_argument('--timeout', '-t', type=float, default=5.0,
                        help='Serial timeout in seconds (default: 5.0)')
@@ -333,9 +393,10 @@ Examples:
     has_primary = args.serial is not None
     has_secondary = args.secondary_serial is not None
     has_bt = args.set_bluetooth_name
+    has_read = args.read
     
-    if not has_primary and not has_secondary and not has_bt:
-        parser.error("At least one of --serial, --secondary-serial, or --set-bluetooth-name must be specified")
+    if not has_primary and not has_secondary and not has_bt and not has_read:
+        parser.error("At least one of --serial, --secondary-serial, --set-bluetooth-name, or --read must be specified")
     
     # If primary serial is set, date is required
     if has_primary and args.date is None:
@@ -362,6 +423,16 @@ def main():
         
         # Initialize service mode
         send_service_mode_init(ser)
+        
+        # Read hardware data if requested
+        if args.read:
+            read_hardware_data(ser)
+            if not args.serial and not args.secondary_serial and not args.set_bluetooth_name:
+                # Only reading, exit cleanly
+                exit_service_mode(ser)
+                print("\nDone!")
+                ser.close()
+                return
         
         # Write primary production data if specified
         if args.serial is not None:

--- a/OtherSources/stm32f4xx_hal_msp_hw1.c
+++ b/OtherSources/stm32f4xx_hal_msp_hw1.c
@@ -564,7 +564,7 @@ void HAL_UART_MspInit(UART_HandleTypeDef* huart)
     GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-#ifdef USART1_CTS_PIN
+#ifdef USARTx_CTS_PIN
     GPIO_InitStruct.Pin = GPIO_PIN_11|GPIO_PIN_12;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
@@ -649,7 +649,7 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* huart)
     */
     HAL_GPIO_DeInit(GPIOA, GPIO_PIN_9|GPIO_PIN_10);
 
-#ifdef USART1_CTS_PIN
+#ifdef USARTx_CTS_PIN
     HAL_GPIO_DeInit(GPIOA, GPIO_PIN_11|GPIO_PIN_12);
 #endif
 

--- a/OtherSources/stm32f4xx_hal_msp_hw1.c
+++ b/OtherSources/stm32f4xx_hal_msp_hw1.c
@@ -564,13 +564,16 @@ void HAL_UART_MspInit(UART_HandleTypeDef* huart)
     GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-#ifdef USART1_CTS_PIN
-  GPIO_InitStruct.Pin = GPIO_PIN_11|GPIO_PIN_12;
-  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FAST;
-  GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
-  HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+#ifdef USARTx_CTS_PIN
+  if(huart->Init.HwFlowCtl != UART_HWCONTROL_NONE)
+  {
+    GPIO_InitStruct.Pin = GPIO_PIN_11|GPIO_PIN_12;
+    GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+    GPIO_InitStruct.Pull = GPIO_NOPULL;
+    GPIO_InitStruct.Speed = GPIO_SPEED_FAST;
+    GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
+    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+  }
 #endif
 
 		HAL_NVIC_SetPriority(USART1_IRQn, 0, 1);

--- a/OtherSources/stm32f4xx_hal_msp_hw1.c
+++ b/OtherSources/stm32f4xx_hal_msp_hw1.c
@@ -564,16 +564,13 @@ void HAL_UART_MspInit(UART_HandleTypeDef* huart)
     GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
 
-#ifdef USARTx_CTS_PIN
-  if(huart->Init.HwFlowCtl != UART_HWCONTROL_NONE)
-  {
+#ifdef USART1_CTS_PIN
     GPIO_InitStruct.Pin = GPIO_PIN_11|GPIO_PIN_12;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FAST;
     GPIO_InitStruct.Alternate = GPIO_AF7_USART1;
     HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
-  }
 #endif
 
 		HAL_NVIC_SetPriority(USART1_IRQn, 0, 1);
@@ -652,7 +649,7 @@ void HAL_UART_MspDeInit(UART_HandleTypeDef* huart)
     */
     HAL_GPIO_DeInit(GPIOA, GPIO_PIN_9|GPIO_PIN_10);
 
-#ifdef USARTx_CTS_PIN
+#ifdef USART1_CTS_PIN
     HAL_GPIO_DeInit(GPIOA, GPIO_PIN_11|GPIO_PIN_12);
 #endif
 


### PR DESCRIPTION
- **Fix Setting of the BLE Name.**
- **Next try.**
- **Bootloader with Recovery for Factory Reset Stollmann Module.**
- **Made it work!**
- **Cleanup.**
- **Fix receive loop.**
- **Fix setting the manufacturing data.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated Bluetooth recovery with multi-baud probing, manual RTS handling, and full reinitialization flow
  * Support for BLE naming alongside Classic name
  * Manufacturing-data read option in the configuration tool

* **Bug Fixes**
  * Improved UART reliability with polling fallback and error-triggered recovery
  * More robust Bluetooth init/config sequencing and deferred reinit after forced name changes
  * Simplified bootloader update-trigger logic

* **Documentation/Tooling**
  * CLI reconnection/retry handling for Bluetooth name setup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->